### PR TITLE
fix: Fixed missing playlist track issue

### DIFF
--- a/src/interfaces/media.interfaces.ts
+++ b/src/interfaces/media.interfaces.ts
@@ -152,7 +152,8 @@ export interface IMediaPlaylistData {
 }
 
 export interface IMediaPlaylistTrackData {
-  id: string;
+  provider: string;
+  provider_id: string;
   added_at: number;
 }
 
@@ -169,5 +170,6 @@ export interface IMediaPlaylistInputData {
 }
 
 export interface IMediaPlaylistTrackInputData {
-  id: string;
+  provider: string;
+  provider_id: string;
 }


### PR DESCRIPTION
## Description
- This adds a hack where in case a track from playlist goes missing (when user deletes track from disk), instead of causing a crash, it simply ignores the track from the list.
- If track is missing and still shows up on UI, playing it does nothing.

## Tests

### Manual test cases run
NA