### PR TITLE
fix: Opening any link pressing ctrl button opens up a new unresponsive window

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -314,12 +314,19 @@ class App implements IAppMain {
       }
     });
 
+    // TODO: For now we don't support opening up external links,
+    //  we are ignoring every external link for now
     // open urls in the user's browser
     // @ts-ignore
-    mainWindow.webContents.on('new-window', (event, url) => {
-      event.preventDefault();
-      shell.openExternal(url);
-    });
+    // mainWindow.webContents.on('new-window', (event, url) => {
+    //   event.preventDefault();
+    //   shell.openExternal(url);
+    // });
+
+    // prevent new window on Ctrl+Click or target="_blank"
+    mainWindow.webContents.setWindowOpenHandler(() => ({
+      action: 'deny',
+    }));
 
     // run builders
     this.runBuilders(mainWindow);


### PR DESCRIPTION
## Description
This fixes the issue when user opens up any link via pressing "Ctrl" button, it opened a new blank window. This fixes the issue and ignores the click entirely.

## Tests

### Manual test cases run
- Opening up a link opens up as usual
- Opening up link while pressing Ctrl does nothing