### PR TITLE
feat: Double clicking on media track should play it

### DIFF
--- a/src/components/media-track-list/media-track-list.component.tsx
+++ b/src/components/media-track-list/media-track-list.component.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { MediaTrackListProvider } from '../../contexts';
 import { IMediaTrack, IMediaTrackList } from '../../interfaces';
 
-import { MediaTrackComponent } from '../media-track/media-track.component';
+import { MediaTrack } from '../media-track/media-track.component';
 
 // import styles from './media-track-list.component.css';
 //
@@ -32,7 +32,7 @@ export function MediaTrackListComponent(props: {
         mediaTrackList={mediaTrackList}
       >
         {mediaTracks.map((mediaTrack, mediaTrackPointer) => (
-          <MediaTrackComponent
+          <MediaTrack
             key={mediaTrack.id}
             mediaTrack={mediaTrack}
             mediaTrackPointer={mediaTrackPointer}

--- a/src/pages/player-queue/player-queue.component.tsx
+++ b/src/pages/player-queue/player-queue.component.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames/bind';
 import { useSelector } from 'react-redux';
 import _ from 'lodash';
 
-import { MediaTrackComponent, MediaTrackContextMenu, MediaTrackContextMenuItem } from '../../components';
+import { MediaTrack, MediaTrackContextMenu, MediaTrackContextMenuItem } from '../../components';
 import { MediaEnums } from '../../enums';
 import { IMediaQueueTrack } from '../../interfaces';
 import { RootState } from '../../reducers';
@@ -52,7 +52,7 @@ export function PlayerQueueComponent() {
                 {I18nService.getString('label_player_queue_current_track')}
               </div>
               <div className={cx('player-queue-section-content')}>
-                <MediaTrackComponent
+                <MediaTrack
                   mediaTrack={mediaPlaybackCurrentMediaTrack}
                   mediaTrackContextMenuId={MediaContextMenus.PlayingTrack}
                   isPlaying={mediaPlaybackState === MediaEnums.MediaPlaybackState.Playing}
@@ -82,7 +82,7 @@ export function PlayerQueueComponent() {
               </div>
               <div className={cx('player-queue-section-content')}>
                 {mediaPlaybackUpcomingTracks.map((mediaTrack, mediaTrackPointer) => (
-                  <MediaTrackComponent
+                  <MediaTrack
                     key={mediaTrack.queue_entry_id}
                     mediaTrack={mediaTrack}
                     mediaTrackPointer={mediaTrackPointer}


### PR DESCRIPTION
## Description
Added support for toggling media playback for a track when user double clicks on it

## Tests

### Manual test cases run
- If track is playing and track is double clicked, app should pause the playback
- If track is paused and track is double clicked, app should resume/start the playback