### PR TITLE
fix: Fix issue where app crashes in case the track could not be found on storage

### DIFF
--- a/src/main.prod.js.LICENSE.txt
+++ b/src/main.prod.js.LICENSE.txt
@@ -1,9 +1,3 @@
-/*
-object-assign
-(c) Sindre Sorhus
-@license MIT
-*/
-
 /*!
  * Timm
  *
@@ -208,6 +202,16 @@ object-assign
  * Released under MIT license <https://lodash.com/license>
  * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
  * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ */
+
+/**
+ * @license React
+ * react.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 //! moment.js

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,9 +113,15 @@ class App implements IAppMain {
   }
 
   registerAsyncMessageHandler(messageChannel: string, messageHandler: AppAsyncMessageHandler, messageHandlerCtx?: any): void {
-    ipcMain.handle(messageChannel, (_event, ...args) => {
-      debug('ipc (async) - received message - channel - %s', messageChannel);
-      return messageHandler.apply(messageHandlerCtx, args);
+    ipcMain.handle(messageChannel, async (_event, ...args) => {
+      try {
+        debug('ipc (async) - received message - channel - %s', messageChannel);
+        return await messageHandler.apply(messageHandlerCtx, args);
+      } catch (err) {
+        // electron serializes the error before sending it back to the renderer
+        // explicitly send the full shape, set a flag and handle on renderer accordingly
+        return { __isError: true, ...err };
+      }
     });
   }
 


### PR DESCRIPTION
## Description
This fix now silently ignores the ENOENT error received when reading non-existing directory. Tracks part of the removed directory(s) are automatically removed as part of the sync process.

## Tests

### Manual test cases run
- If user opens up the app and the added directory is not found anymore, the app does not crashes.
- Tracks part of the removed directory are removed from the library
- If user adds back the saved directory to fs, directory is sync'd again as usual
- If user is currently playing a track from removed directory, it keeps on playing as normal
- If user attempts to play the track once app reopens and before the sync has removed the file from library, app does not crashes and playback remains in loading state
- If user reopens the app and removed track is currently in playback, once sync finishes the track is automatically removed.
