### PR TITLE
fix: Media track playback state stuck at Loading

### DIFF
--- a/src/components/media-player-ribbon/media-player-controls.component.tsx
+++ b/src/components/media-player-ribbon/media-player-controls.component.tsx
@@ -24,12 +24,15 @@ export function MediaPlayerControls() {
     mediaPlaybackQueueRepeatType,
   } = useSelector((state: RootState) => state.mediaPlayer);
 
+  const isPlaybackDisabled = mediaPlaybackState === MediaEnums.MediaPlaybackState.Loading;
+
   useEffect(() => {
     const handleOnKeyDown = (event: KeyboardEvent) => {
       if (
         Events.isSpaceKey(event)
         && document.activeElement
         && !DOMUtils.isElementEditable(document.activeElement)
+        && !isPlaybackDisabled
       ) {
         event.preventDefault();
         MediaPlayerService.toggleMediaPlayback();
@@ -41,7 +44,9 @@ export function MediaPlayerControls() {
     return () => {
       window.removeEventListener('keydown', handleOnKeyDown);
     };
-  }, []);
+  }, [
+    isPlaybackDisabled,
+  ]);
 
   return (
     <Row className={cx('media-player-controls-container')}>
@@ -77,7 +82,7 @@ export function MediaPlayerControls() {
           )
           : (
             <Button
-              disabled={mediaPlaybackState === MediaEnums.MediaPlaybackState.Loading}
+              disabled={isPlaybackDisabled}
               className={cx('media-player-control', 'media-player-control-lg')}
               onButtonSubmit={() => {
                 MediaPlayerService.resumeMediaPlayer();

--- a/src/providers/media-local/media-local.interfaces.ts
+++ b/src/providers/media-local/media-local.interfaces.ts
@@ -1,17 +1,15 @@
-import {
-  IMediaTrack,
-} from '../../interfaces';
+import { IMediaTrack } from '../../interfaces';
 
 export interface IMediaLocalSettings {
   library: {
-    directories: string[]
+    directories: string[];
   }
 }
 
 export interface IMediaLocalTrack extends IMediaTrack {
   extra: {
     location: {
-      address: string,
-    },
-  },
+      address: string;
+    }
+  }
 }

--- a/src/providers/media-local/media-local.utils.ts
+++ b/src/providers/media-local/media-local.utils.ts
@@ -2,13 +2,13 @@ class MediaLocalUtils {
   parseMediaMetadataDuration(mediaMetadataDuration?: number): number {
     // this is the duration we receive from media metadata utility (music-metadata)
     // both parseMediaMetadataDuration and parseMediaPlaybackDuration need to be consistent
-    return mediaMetadataDuration ? Math.round(mediaMetadataDuration) : 0;
+    return mediaMetadataDuration ? Math.ceil(mediaMetadataDuration) : 0;
   }
 
   parseMediaPlaybackDuration(mediaPlaybackDuration?: number): number {
     // this is the duration we receive from media playback utility (howler)
     // both parseMediaMetadataDuration and parseMediaPlaybackDuration need to be consistent
-    return mediaPlaybackDuration ? Math.round(mediaPlaybackDuration) : 0;
+    return mediaPlaybackDuration ? Math.ceil(mediaPlaybackDuration) : 0;
   }
 }
 

--- a/src/reducers/media-player.reducer.ts
+++ b/src/reducers/media-player.reducer.ts
@@ -129,13 +129,17 @@ export default (state: MediaPlayerState = mediaPlayerInitialState, action: Media
     }
     case MediaEnums.MediaPlayerActions.UpdatePlaybackProgress: {
       // data.mediaPlaybackProgress: number
+      // data.mediaPlaybackState
+      const { mediaPlaybackState, mediaPlaybackProgress } = action.data;
+
       if (!state.mediaPlaybackCurrentMediaTrack) {
         throw new Error('MediaPlayerReducer encountered error at UpdatePlaybackProgress - No loaded media track was found');
       }
 
       return {
         ...state,
-        mediaPlaybackCurrentMediaProgress: action.data.mediaPlaybackProgress,
+        mediaPlaybackState,
+        mediaPlaybackCurrentMediaProgress: mediaPlaybackProgress,
       };
     }
     case MediaEnums.MediaPlayerActions.UpdatePlaybackVolume: {

--- a/src/services/media-library.service.ts
+++ b/src/services/media-library.service.ts
@@ -1,6 +1,4 @@
-import {
-  assign, defaults, isEmpty, isNil,
-} from 'lodash';
+import _ from 'lodash';
 
 import { Semaphore } from 'async-mutex';
 
@@ -89,7 +87,7 @@ class MediaLibraryService {
   async checkAndInsertMediaArtist(mediaArtistInputData: DataStoreInputData<IMediaArtistData>): Promise<IMediaArtist> {
     let mediaArtistData;
 
-    if (!isNil(mediaArtistInputData.provider_id)) {
+    if (!_.isNil(mediaArtistInputData.provider_id)) {
       mediaArtistData = await MediaArtistDatastore.findMediaArtist({
         provider: mediaArtistInputData.provider,
         provider_id: mediaArtistInputData.provider_id,
@@ -99,9 +97,11 @@ class MediaLibraryService {
     }
 
     if (mediaArtistData) {
-      mediaArtistData = await MediaArtistDatastore.updateArtistById(mediaArtistData.id, {
-        sync_timestamp: mediaArtistInputData.sync_timestamp,
-      });
+      mediaArtistData = await MediaArtistDatastore.updateArtistById(mediaArtistData.id, _.pick(mediaArtistInputData, [
+        'sync_timestamp',
+        'artist_name',
+        'extra',
+      ]));
     } else {
       mediaArtistData = await MediaArtistDatastore.insertMediaArtist({
         provider: mediaArtistInputData.provider,
@@ -119,7 +119,7 @@ class MediaLibraryService {
   async checkAndInsertMediaAlbum(mediaAlbumInputData: DataStoreInputData<IMediaAlbumData>): Promise<IMediaAlbum> {
     let mediaTrackAlbumData;
 
-    if (!isNil(mediaAlbumInputData.provider_id)) {
+    if (!_.isNil(mediaAlbumInputData.provider_id)) {
       mediaTrackAlbumData = await MediaAlbumDatastore.findMediaAlbum({
         provider: mediaAlbumInputData.provider,
         provider_id: mediaAlbumInputData.provider_id,
@@ -129,9 +129,12 @@ class MediaLibraryService {
     }
 
     if (mediaTrackAlbumData) {
-      mediaTrackAlbumData = await MediaAlbumDatastore.updateAlbumById(mediaTrackAlbumData.id, {
-        sync_timestamp: mediaAlbumInputData.sync_timestamp,
-      });
+      mediaTrackAlbumData = await MediaAlbumDatastore.updateAlbumById(mediaTrackAlbumData.id, _.pick(mediaAlbumInputData, [
+        'sync_timestamp',
+        'album_name',
+        'album_artist_id',
+        'extra',
+      ]));
     } else {
       mediaTrackAlbumData = await MediaAlbumDatastore.insertMediaAlbum({
         provider: mediaAlbumInputData.provider,
@@ -150,7 +153,7 @@ class MediaLibraryService {
   async checkAndInsertMediaTrack(mediaTrackInputData: DataStoreInputData<IMediaTrackData>): Promise<IMediaTrack> {
     let mediaTrackData;
 
-    if (!isNil(mediaTrackInputData.provider_id)) {
+    if (!_.isNil(mediaTrackInputData.provider_id)) {
       mediaTrackData = await MediaTrackDatastore.findMediaTrack({
         provider: mediaTrackInputData.provider,
         provider_id: mediaTrackInputData.provider_id,
@@ -160,9 +163,15 @@ class MediaLibraryService {
     }
 
     if (mediaTrackData) {
-      mediaTrackData = await MediaTrackDatastore.updateTrackById(mediaTrackData.id, {
-        sync_timestamp: mediaTrackInputData.sync_timestamp,
-      });
+      mediaTrackData = await MediaTrackDatastore.updateTrackById(mediaTrackData.id, _.pick(mediaTrackInputData, [
+        'sync_timestamp',
+        'track_name',
+        'track_number',
+        'track_duration',
+        'track_artist_ids',
+        'track_album_id',
+        'extra',
+      ]));
     } else {
       mediaTrackData = await MediaTrackDatastore.insertMediaTrack({
         provider: mediaTrackInputData.provider,
@@ -338,7 +347,7 @@ class MediaLibraryService {
   // create API
 
   async createMediaPlaylist(mediaPlaylistInputData?: IMediaPlaylistInputData): Promise<IMediaPlaylist> {
-    const inputData: DataStoreInputData<IMediaPlaylistData> = defaults(mediaPlaylistInputData, {
+    const inputData: DataStoreInputData<IMediaPlaylistData> = _.defaults(mediaPlaylistInputData, {
       name: await this.getDefaultNewPlaylistName(),
       tracks: [],
       created_at: Date.now(),
@@ -373,7 +382,7 @@ class MediaLibraryService {
       mediaPlaylistTrackInputDataList,
     );
 
-    if (!isEmpty(existingInputDataList) && !options?.ignoreExisting) {
+    if (!_.isEmpty(existingInputDataList) && !options?.ignoreExisting) {
       // not allowed to add duplicate tracks, throw error
       throw new MediaLibraryPlaylistDuplicateTracksError(existingInputDataList, newInputDataList);
     }
@@ -584,7 +593,7 @@ class MediaLibraryService {
   }
 
   private async buildMediaTrack(mediaTrackData: IMediaTrackData, loadMediaTrack = false): Promise<IMediaTrack> {
-    const mediaTrack = assign({}, mediaTrackData, {
+    const mediaTrack = _.assign({}, mediaTrackData, {
       track_artists: await this.buildMediaArtists(mediaTrackData.track_artist_ids, loadMediaTrack),
       track_album: await this.buildMediaAlbum(mediaTrackData.track_album_id, loadMediaTrack),
     });
@@ -617,7 +626,7 @@ class MediaLibraryService {
       mediaAlbumData = mediaAlbum;
     }
 
-    const mediaAlbumBuilt = assign({}, mediaAlbumData, {
+    const mediaAlbumBuilt = _.assign({}, mediaAlbumData, {
       album_artist: await this.buildMediaArtist(mediaAlbumData.album_artist_id),
     });
 
@@ -721,7 +730,7 @@ class MediaLibraryService {
   }
 
   private async buildMediaPlaylist(mediaPlaylistData: IMediaPlaylistData) {
-    return assign(mediaPlaylistData, {});
+    return _.assign(mediaPlaylistData, {});
   }
 
   private async buildMediaPlaylists(mediaPlaylistDataList: IMediaPlaylistData[]) {
@@ -735,7 +744,7 @@ class MediaLibraryService {
     // @ts-ignore
     return Promise
       .all(mediaPlaylistTrackDataList.map(mediaPlaylistTrackData => this.buildMediaPlaylistTrack(mediaPlaylistTrackData)))
-      .then(mediaPlaylistTracks => mediaPlaylistTracks.filter(mediaPlaylistTrack => !isNil(mediaPlaylistTrack)));
+      .then(mediaPlaylistTracks => mediaPlaylistTracks.filter(mediaPlaylistTrack => !_.isNil(mediaPlaylistTrack)));
   }
 
   private async buildMediaPlaylistTrack(mediaPlaylistTrackData: IMediaPlaylistTrackData): Promise<IMediaPlaylistTrack | undefined> {
@@ -744,7 +753,7 @@ class MediaLibraryService {
       return undefined;
     }
 
-    return assign({}, mediaPlaylistTrackData, mediaTrack);
+    return _.assign({}, mediaPlaylistTrackData, mediaTrack);
   }
 
   private async getDefaultNewPlaylistName(): Promise<string> {

--- a/src/services/media-player.service.ts
+++ b/src/services/media-player.service.ts
@@ -448,10 +448,6 @@ class MediaPlayerService {
       return;
     }
 
-    store.dispatch({
-      type: MediaEnums.MediaPlayerActions.LoadingTrack,
-    });
-
     mediaPlaybackCurrentPlayingInstance
       .resumePlayback()
       .then((mediaPlaybackResumed) => {
@@ -638,7 +634,7 @@ class MediaPlayerService {
 
     // update playback progress state to the requested one right away
     // this is being done in order to prevent delay between seek request and actual audio seek success response
-    this.updateMediaPlaybackProgress(mediaTrackSeekPosition);
+    this.updateMediaPlaybackProgress(mediaTrackSeekPosition, true);
 
     mediaPlaybackCurrentPlayingInstance
       .seekPlayback(mediaTrackSeekPosition)
@@ -1005,12 +1001,15 @@ class MediaPlayerService {
     }
   }
 
-  private updateMediaPlaybackProgress(mediaPlaybackProgress: number): void {
+  // when seeking, we will preserve the playback state (example: playback might be paused but user still requests seek)
+  // when not seeking, playback state will be forced to Playing
+  private updateMediaPlaybackProgress(mediaPlaybackProgress: number, seeking?: boolean): void {
     const {
       mediaPlayer,
     } = store.getState();
 
     const {
+      mediaPlaybackState,
       mediaPlaybackCurrentMediaProgress = 0,
     } = mediaPlayer;
 
@@ -1023,6 +1022,7 @@ class MediaPlayerService {
     store.dispatch({
       type: MediaEnums.MediaPlayerActions.UpdatePlaybackProgress,
       data: {
+        mediaPlaybackState: seeking ? mediaPlaybackState : MediaEnums.MediaPlaybackState.Playing,
         mediaPlaybackProgress,
       },
     });

--- a/src/services/media-player.service.ts
+++ b/src/services/media-player.service.ts
@@ -459,7 +459,7 @@ class MediaPlayerService {
         store.dispatch({
           type: MediaEnums.MediaPlayerActions.Play,
           data: {
-            mediaPlaybackProgress: mediaPlaybackCurrentPlayingInstance.getPlaybackProgress(),
+            mediaPlaybackProgress: this.getCurrentPlaybackProgress(),
           },
         });
 
@@ -835,7 +835,7 @@ class MediaPlayerService {
     store.dispatch({
       type: MediaEnums.MediaPlayerActions.Play,
       data: {
-        mediaPlaybackProgress: mediaPlayback.getPlaybackProgress(),
+        mediaPlaybackProgress: this.getCurrentPlaybackProgress(),
       },
     });
 
@@ -976,7 +976,7 @@ class MediaPlayerService {
       return;
     }
 
-    const mediaPlaybackProgress = mediaPlaybackCurrentPlayingInstance.getPlaybackProgress();
+    const mediaPlaybackProgress = this.getCurrentPlaybackProgress();
     this.updateMediaPlaybackProgress(mediaPlaybackProgress);
 
     if (mediaPlaybackCurrentPlayingInstance.checkIfPlaying()) {
@@ -1026,6 +1026,22 @@ class MediaPlayerService {
         mediaPlaybackProgress,
       },
     });
+  }
+
+  private getCurrentPlaybackProgress(): number {
+    const { mediaPlayer } = store.getState();
+    const { mediaPlaybackCurrentMediaTrack, mediaPlaybackCurrentPlayingInstance } = mediaPlayer;
+
+    if (!mediaPlaybackCurrentMediaTrack || !mediaPlaybackCurrentPlayingInstance) {
+      throw new Error('Cannot get current playback progress - track or instance missing');
+    }
+
+    // providers are not allowed to report progress greater than the
+    // set track duration
+    return Math.min(
+      mediaPlaybackCurrentPlayingInstance.getPlaybackProgress(),
+      mediaPlaybackCurrentMediaTrack.track_duration,
+    );
   }
 
   private retryMediaProgressReporting(): boolean {


### PR DESCRIPTION
## Description
- This fixes issue where upon requesting seek, playback state remained stuck at Loading
- This also fixes issue where provider was reporting progress duration greater than the track_duration
- This fixes the utility in local media provider which now uses `Math.ceill` to round up the track duration
- This adds back support for updating media entities in place with specific properties in check and inserts

## Tests

### Manual test cases run
- When user plays track, state should be Playing
- When user requests seek, state should remain Playing
- When app is reopened and track is loaded again, it should seek with old progress and playback should remain as Paused
- When playback state is Loading, playback toggle via Spacebar should be disabled as well