### PR TITLE
feat: Added support for provider input in MediaLikedTrack

### DIFF
--- a/src/app/browser/browser.component.css
+++ b/src/app/browser/browser.component.css
@@ -8,9 +8,11 @@
 
 .browser-header {
   display: flex;
+  align-items: center;
   flex: 0 0 50px;
   height: var(--titlebar-overlay-height);
   margin: 5px;
+  gap: 15px;
 }
 
 .browser-viewport {

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -109,7 +109,7 @@ export function Button(props: ButtonProps) {
         aria-disabled={disabled}
         ref={mediaButtonContainerRef}
         role="button"
-        tabIndex={0}
+        tabIndex={disabled ? -1 : 0}
         // for some reason, in our custom implementation setting delay directly to tooltip is not working
         // we use timeout then to open up the tooltip
         onMouseEnter={() => setTooltipOpen(true)}

--- a/src/components/media-header-navigation-link/media-header-navigation-link.component.css
+++ b/src/components/media-header-navigation-link/media-header-navigation-link.component.css
@@ -1,5 +1,4 @@
 .media-header-navigation-link {
-  margin: 0 10px;
   padding: 10px 15px;
   font-size: 15px;
   border-radius: 5px;

--- a/src/components/media-header-navigation-link/media-header-navigation-link.component.tsx
+++ b/src/components/media-header-navigation-link/media-header-navigation-link.component.tsx
@@ -8,7 +8,7 @@ import styles from './media-header-navigation-link.component.css';
 
 const cx = classNames.bind(styles);
 
-export function MediaHeaderNavigationLinkComponent(props: {
+export function MediaHeaderNavigationLink(props: {
   tName: string,
   path: string,
 }) {

--- a/src/components/media-liked-tracks-delete-modal/media-liked-tracks-delete-modal.component.tsx
+++ b/src/components/media-liked-tracks-delete-modal/media-liked-tracks-delete-modal.component.tsx
@@ -3,25 +3,26 @@ import { Modal } from 'react-bootstrap';
 
 import { ModalComponent } from '../../contexts';
 import { useDataAction } from '../../hooks';
+import { IMediaLikedTrackInputData } from '../../interfaces';
 import { I18nService, MediaLikedTrackService } from '../../services';
 
 import { Button } from '../button/button.component';
 
 export const MediaLikedTracksDeleteModal: ModalComponent<{
-  likedTracksIds: string[];
+  likedTracksInputList: IMediaLikedTrackInputData[];
 }, {
-  deletedLikedTrackIds: string[];
+  deletedLikedTrackInputList: IMediaLikedTrackInputData[];
 }> = (props) => {
   const {
-    likedTracksIds,
+    likedTracksInputList,
     onComplete,
   } = props;
 
   const deleteLikedTracks = useDataAction(async () => {
-    await MediaLikedTrackService.removeTracksFromLiked(likedTracksIds);
+    await MediaLikedTrackService.removeTracksFromLiked(likedTracksInputList);
 
     onComplete({
-      deletedLikedTrackIds: likedTracksIds,
+      deletedLikedTrackInputList: likedTracksInputList,
     });
   });
 

--- a/src/components/media-track/media-track.component.css
+++ b/src/components/media-track/media-track.component.css
@@ -63,5 +63,5 @@
   font-size: 12px;
   letter-spacing: 1px;
   text-align: right;
-  width: 100px;
+  width: 70px; /* TODO: Hack to fit long durations (eg: 02:35:40) */
 }

--- a/src/datastores/media-liked-track.datastore.ts
+++ b/src/datastores/media-liked-track.datastore.ts
@@ -10,8 +10,6 @@ class MediaLikedTracksDatastore {
       indexes: [{
         field: 'id',
         unique: true,
-      }, {
-        field: 'track_id',
       }],
     });
   }

--- a/src/enums/media.enums.ts
+++ b/src/enums/media.enums.ts
@@ -21,7 +21,7 @@ export enum MediaLibraryActions {
   RemoveMediaTrackFromLiked = 'media/library/removeMediaTrackFromLiked',
   SetPinnedItems = 'media/library/setPinnedItems',
   AddPinnedItem = 'media/library/addPinnedItem',
-  RemovePinnedCollectionItem = 'media/library/removePinnedCollectionItem',
+  RemovePinnedItem = 'media/library/removePinnedItem',
 }
 
 export enum MediaPlayerActions {

--- a/src/hooks/use-media-track-like.tsx
+++ b/src/hooks/use-media-track-like.tsx
@@ -13,15 +13,15 @@ export function useMediaTrackLike(props: {
   const { mediaTrack, mediaTracks } = props;
   const [isLikeStatusLoading, setIsLikeStatusLoading] = useState(false);
 
-  const isTrackLiked = useSelector(makeSelectIsTrackLiked(mediaTrack?.id));
-  const areAllTracksLiked = useSelector(makeSelectAreAllTracksLiked(mediaTracks?.map(t => t.id)));
+  const isTrackLiked = useSelector(makeSelectIsTrackLiked(mediaTrack));
+  const areAllTracksLiked = useSelector(makeSelectAreAllTracksLiked(mediaTracks));
 
   useEffect(() => {
     if (!mediaTrack) {
       return;
     }
 
-    MediaLikedTrackService.loadTrackLikedStatus(mediaTrack.id);
+    MediaLikedTrackService.loadTrackLikedStatus(mediaTrack);
   }, [
     mediaTrack,
   ]);
@@ -32,7 +32,7 @@ export function useMediaTrackLike(props: {
     }
 
     mediaTracks.forEach((track: IMediaTrack) => {
-      MediaLikedTrackService.loadTrackLikedStatus(track.id);
+      MediaLikedTrackService.loadTrackLikedStatus(track);
     });
   }, [
     mediaTracks,
@@ -45,18 +45,18 @@ export function useMediaTrackLike(props: {
       if (mediaTrack) {
         if (isTrackLiked) {
           // remove
-          await MediaLikedTrackService.removeTrackFromLiked(mediaTrack.id);
+          await MediaLikedTrackService.removeTrackFromLiked(mediaTrack);
         } else {
           // add
-          await MediaLikedTrackService.addTrackToLiked(mediaTrack.id);
+          await MediaLikedTrackService.addTrackToLiked(mediaTrack);
         }
       } else if (mediaTracks && !isEmpty(mediaTracks)) {
         if (areAllTracksLiked) {
           // remove
-          await MediaLikedTrackService.removeTracksFromLiked(mediaTracks.map(track => track.id));
+          await MediaLikedTrackService.removeTracksFromLiked(mediaTracks);
         } else {
           // add
-          await MediaLikedTrackService.addTracksToLiked(mediaTracks.map(track => track.id));
+          await MediaLikedTrackService.addTracksToLiked(mediaTracks);
         }
       }
     } catch (error) {

--- a/src/interfaces/media.interfaces.ts
+++ b/src/interfaces/media.interfaces.ts
@@ -195,10 +195,12 @@ export interface IMediaPlaylistTrackUpdateData {
   playlist_track_id: string;
 }
 
-export interface IMediaLikedTrackData {
+export interface IMediaLikedTrackData extends IMediaProviderTrackData {
   id: string;
-  track_id: string;
   added_at: number;
+}
+
+export interface IMediaLikedTrackInputData extends IMediaProviderTrackData {
 }
 
 export interface IMediaLikedTrack extends IMediaLikedTrackData, IMediaTrack {

--- a/src/pages/library/library.component.css
+++ b/src/pages/library/library.component.css
@@ -1,6 +1,6 @@
 .library-header-navigation-list {
   display: flex;
   flex-direction: row;
-  align-self: center;
   align-items: center;
+  gap: 15px;
 }

--- a/src/pages/library/library.component.tsx
+++ b/src/pages/library/library.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames/bind';
 
-import { MediaHeaderNavigationLinkComponent, RouterSwitchComponent } from '../../components';
+import { MediaHeaderNavigationLink, RouterSwitchComponent } from '../../components';
 
 import styles from './library.component.css';
 import routes from './library.routes';
@@ -21,7 +21,7 @@ export function LibraryHeader() {
     <div className={cx('library-header')}>
       <div className={cx('library-header-navigation-list')}>
         {routes.map(route => route.tHeaderName && (
-          <MediaHeaderNavigationLinkComponent
+          <MediaHeaderNavigationLink
             key={route.path}
             tName={route.tHeaderName}
             path={route.path}

--- a/src/pages/liked-tracks/liked-tracks.component.tsx
+++ b/src/pages/liked-tracks/liked-tracks.component.tsx
@@ -27,16 +27,19 @@ export function LikedTracksPage() {
   const sortedMediaLikedTracks = useSelector(selectSortedLikedTracks);
 
   const handleSelectionDelete = useCallback((likedTracksIds: string[]) => new Promise<boolean>((resolve) => {
+    const mediaLikedTrackForDelete = sortedMediaLikedTracks.filter(track => likedTracksIds.includes(track.id));
+
     showModal(MediaLikedTracksDeleteModal, {
-      likedTracksIds,
+      likedTracksInputList: mediaLikedTrackForDelete,
     }, {
       onComplete: (res) => {
         // success signal if selected were deleted
-        resolve(!isEmpty(res?.deletedLikedTrackIds));
+        resolve(!isEmpty(res?.deletedLikedTrackInputList));
       },
     });
   }), [
     showModal,
+    sortedMediaLikedTracks,
   ]);
 
   useEffect(() => {

--- a/src/pages/player/player.component.css
+++ b/src/pages/player/player.component.css
@@ -1,6 +1,6 @@
 .player-header-navigation-list {
   display: flex;
   flex-direction: row;
-  align-self: center;
   align-items: center;
+  gap: 15px;
 }

--- a/src/pages/player/player.component.tsx
+++ b/src/pages/player/player.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames/bind';
 
-import { MediaHeaderNavigationLinkComponent, RouterSwitchComponent } from '../../components';
+import { MediaHeaderNavigationLink, RouterSwitchComponent } from '../../components';
 
 import styles from './player.component.css';
 import routes from './player.routes';
@@ -21,7 +21,7 @@ export function PlayerHeader() {
     <div className={cx('player-header')}>
       <div className={cx('player-header-navigation-list')}>
         {routes.map(route => route.tHeaderName && (
-          <MediaHeaderNavigationLinkComponent
+          <MediaHeaderNavigationLink
             key={route.path}
             tName={route.tHeaderName}
             path={route.path}

--- a/src/reducers/media-library.reducer.ts
+++ b/src/reducers/media-library.reducer.ts
@@ -310,7 +310,7 @@ export default (state: MediaLibraryState = mediaLibraryInitialState, action: Med
       };
     }
     case MediaLibraryActions.RemoveMediaTrackFromLiked: {
-      // data.mediaLikedTrackInput: IMediaLikedTrackInput
+      // data.mediaLikedTrackInput: IMediaLikedTrackInputData
       const { mediaLikedTrackInput } = action.data;
       const mediaLikedTrackKey = MediaUtils.getLikedTrackKeyFromInput(mediaLikedTrackInput);
 
@@ -354,8 +354,8 @@ export default (state: MediaLibraryState = mediaLibraryInitialState, action: Med
         },
       };
     }
-    case MediaLibraryActions.RemovePinnedCollectionItem: {
-      // data.mediaCollectionItem: IMediaCollectionItem
+    case MediaLibraryActions.RemovePinnedItem: {
+      // data.mediaPinnedItemInput: IMediaPinnedItemInputData
       const { mediaPinnedItemInput } = action.data;
       const mediaPinnedItemKey = MediaUtils.getPinnedItemKeyFromInput(mediaPinnedItemInput);
 

--- a/src/reducers/media-library.reducer.ts
+++ b/src/reducers/media-library.reducer.ts
@@ -285,14 +285,18 @@ export default (state: MediaLibraryState = mediaLibraryInitialState, action: Med
 
       return {
         ...state,
-        mediaLikedTracksRecord: keyBy(mediaLikedTracks, 'track_id'),
+        mediaLikedTracksRecord: keyBy(
+          mediaLikedTracks,
+          track => MediaUtils.getLikedTrackKey(track),
+        ),
       };
     }
     case MediaLibraryActions.AddMediaTrackToLiked: {
       // data.mediaLikedTrack: IMediaLikedTrack - liked track to be added
       const { mediaLikedTrack } = action.data;
+      const mediaLikedTrackKey = MediaUtils.getLikedTrackKey(mediaLikedTrack);
 
-      if (state.mediaLikedTracksRecord[mediaLikedTrack.track_id]) {
+      if (state.mediaLikedTracksRecord[mediaLikedTrackKey]) {
         // already there, skip update
         return state;
       }
@@ -301,22 +305,23 @@ export default (state: MediaLibraryState = mediaLibraryInitialState, action: Med
         ...state,
         mediaLikedTracksRecord: {
           ...state.mediaLikedTracksRecord,
-          [mediaLikedTrack.track_id]: mediaLikedTrack,
+          [mediaLikedTrackKey]: mediaLikedTrack,
         },
       };
     }
     case MediaLibraryActions.RemoveMediaTrackFromLiked: {
-      // data.mediaTrackId: string - media track id
-      const { mediaTrackId } = action.data;
+      // data.mediaLikedTrackInput: IMediaLikedTrackInput
+      const { mediaLikedTrackInput } = action.data;
+      const mediaLikedTrackKey = MediaUtils.getLikedTrackKeyFromInput(mediaLikedTrackInput);
 
-      if (!state.mediaLikedTracksRecord[mediaTrackId]) {
+      if (!state.mediaLikedTracksRecord[mediaLikedTrackKey]) {
         // already removed, skip update
         return state;
       }
 
       return {
         ...state,
-        mediaLikedTracksRecord: omit(state.mediaLikedTracksRecord, mediaTrackId),
+        mediaLikedTracksRecord: omit(state.mediaLikedTracksRecord, mediaLikedTrackKey),
       };
     }
     case MediaLibraryActions.SetPinnedItems: {

--- a/src/selectors/media-library.selector.ts
+++ b/src/selectors/media-library.selector.ts
@@ -1,7 +1,7 @@
 import { every, isNil, values } from 'lodash';
 import { createSelector } from 'reselect';
 
-import { IMediaCollectionItem } from '../interfaces';
+import { IMediaLikedTrackInputData, IMediaPinnedItemInputData } from '../interfaces';
 import { RootState } from '../reducers';
 import { MediaUtils } from '../utils';
 
@@ -12,17 +12,17 @@ export const selectSortedLikedTracks = createSelector(
   mediaLikedTracksRecord => MediaUtils.sortMediaLikedTracks(values(mediaLikedTracksRecord)),
 );
 
-export const makeSelectIsTrackLiked = (trackId?: string) => createSelector(
+export const makeSelectIsTrackLiked = (input?: IMediaLikedTrackInputData) => createSelector(
   [selectMediaLikedTracksRecord],
-  mediaLikedTracksRecord => !!trackId && !!mediaLikedTracksRecord[trackId],
+  mediaLikedTracksRecord => !!input && !!mediaLikedTracksRecord[MediaUtils.getLikedTrackKeyFromInput(input)],
 );
 
-export const makeSelectAreAllTracksLiked = (trackIds?: string[]) => createSelector(
+export const makeSelectAreAllTracksLiked = (inputList?: IMediaLikedTrackInputData[]) => createSelector(
   [selectMediaLikedTracksRecord],
   (mediaLikedTracksRecord) => {
-    if (!trackIds || trackIds.length === 0) return false;
+    if (!inputList || inputList.length === 0) return false;
 
-    return every(trackIds, (id: string) => !isNil(mediaLikedTracksRecord[id]));
+    return every(inputList, input => !isNil(mediaLikedTracksRecord[MediaUtils.getLikedTrackKeyFromInput(input)]));
   },
 );
 
@@ -33,7 +33,7 @@ export const selectSortedPinnedItems = createSelector(
   mediaPinnedItemsRecord => MediaUtils.sortMediaPinnedItems(values(mediaPinnedItemsRecord)),
 );
 
-export const makeSelectIsCollectionPinned = (item?: IMediaCollectionItem) => createSelector(
+export const makeSelectIsCollectionPinned = (input?: IMediaPinnedItemInputData) => createSelector(
   [selectMediaPinnedItemsRecord],
-  mediaPinnedItemsRecord => !!item && !!mediaPinnedItemsRecord[MediaUtils.getPinnedItemKeyFromInput(item)],
+  mediaPinnedItemsRecord => !!input && !!mediaPinnedItemsRecord[MediaUtils.getPinnedItemKeyFromInput(input)],
 );

--- a/src/services/media-pinned-item.service.ts
+++ b/src/services/media-pinned-item.service.ts
@@ -35,7 +35,7 @@ class MediaPinnedItemService {
           });
         } else {
           store.dispatch({
-            type: MediaLibraryActions.RemovePinnedCollectionItem,
+            type: MediaLibraryActions.RemovePinnedItem,
             data: {
               mediaPinnedItemInput: input,
             },
@@ -118,7 +118,7 @@ class MediaPinnedItemService {
     });
 
     store.dispatch({
-      type: MediaLibraryActions.RemovePinnedCollectionItem,
+      type: MediaLibraryActions.RemovePinnedItem,
       data: {
         mediaPinnedItemInput: input,
       },

--- a/src/utils/media.utils.ts
+++ b/src/utils/media.utils.ts
@@ -2,6 +2,7 @@ import {
   IMediaAlbum,
   IMediaArtist,
   IMediaLikedTrack,
+  IMediaLikedTrackInputData,
   IMediaPinnedItem,
   IMediaPinnedItemInputData,
   IMediaPlaylist,
@@ -106,4 +107,12 @@ export function getPinnedItemKey(item: IMediaPinnedItem) {
 
 export function getPinnedItemKeyFromInput(input: IMediaPinnedItemInputData) {
   return `${input.type}_${input.id}`;
+}
+
+export function getLikedTrackKey(track: IMediaLikedTrack) {
+  return `${track.provider}_${track.provider_id}`;
+}
+
+export function getLikedTrackKeyFromInput(input: IMediaLikedTrackInputData) {
+  return `${input.provider}_${input.provider_id}`;
 }


### PR DESCRIPTION
## Description
This adds support for accepting provider input (provider, provider_id) for MediaLikedTrack, just liked tracks in MediaPlaylists accept.

This also fixes following issues:
- Fixes styling issues with track duration - Decreased hard coded width
- Fixes styling issues with Header components
- Fixes focus issue with disabled button

## Tests

### Manual test cases run
- Existing liked track functionality should work as expected
- Disabled button should not get focused
