### PR TITLE
fix: Fix text overflowing issues all over the app

### DIFF
--- a/src/app/browser/browser.component.css
+++ b/src/app/browser/browser.component.css
@@ -4,6 +4,7 @@
   flex-direction: column;
   background-color: var(--stage-content-bg-color);
   color: var(--text-light-color);
+  overflow: hidden;
 }
 
 .browser-header {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -39,4 +39,5 @@ export * from './router-link-toggle/router-link-toggle.component';
 export * from './router-link/router-link.component';
 export * from './text/text.component';
 export * from './text-input/text-input.component';
+export * from './text/text-clamp.component';
 export * from './upload/upload-overlay.component';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -37,5 +37,6 @@ export * from './media-cover-picture/media-cover-picture-uploadable.component';
 export * from './router-switch/router-switch.component';
 export * from './router-link-toggle/router-link-toggle.component';
 export * from './router-link/router-link.component';
+export * from './text/text.component';
 export * from './text-input/text-input.component';
 export * from './upload/upload-overlay.component';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -38,6 +38,7 @@ export * from './router-switch/router-switch.component';
 export * from './router-link-toggle/router-link-toggle.component';
 export * from './router-link/router-link.component';
 export * from './text/text.component';
-export * from './text-input/text-input.component';
 export * from './text/text-clamp.component';
+export * from './text/text-marquee.component';
+export * from './text-input/text-input.component';
 export * from './upload/upload-overlay.component';

--- a/src/components/media-collection-item/media-collection-item.component.css
+++ b/src/components/media-collection-item/media-collection-item.component.css
@@ -25,6 +25,7 @@
   align-items: center;
   gap: 20px;
   padding: 10px;
+  min-width: 0; /* allow children to shrink when needed */
 }
 
 .collection-item.compact .collection-item-content {
@@ -37,12 +38,14 @@
 }
 
 .collection-item-info {
+  flex-flow: column;
   display: flex;
   flex-flow: column;
   align-items: flex-start;
-  white-space: nowrap;
-  overflow: hidden;
   gap: 5px;
+  flex: 1 1 auto; /* take remaining horizontal space and be allowed to shrink */
+  min-width: 0;
+  overflow: visible; /* children handle their own overflow */
 }
 
 .collection-item-info-title {
@@ -57,4 +60,10 @@
 
 .collection-item.current .collection-item-info-title {
   font-weight: bold;
+}
+
+.collection-item-info-title,
+.collection-item-info-subtitle {
+  width: 100%;
+  overflow: hidden;
 }

--- a/src/components/media-collection-item/media-collection-item.component.css
+++ b/src/components/media-collection-item/media-collection-item.component.css
@@ -64,6 +64,6 @@
 
 .collection-item-info-title,
 .collection-item-info-subtitle {
-  width: 100%;
+  max-width: 100%;
   overflow: hidden;
 }

--- a/src/components/media-collection-item/media-collection-item.component.tsx
+++ b/src/components/media-collection-item/media-collection-item.component.tsx
@@ -8,6 +8,7 @@ import { IMediaCollectionItem } from '../../interfaces';
 import { RouterLink } from '../router-link/router-link.component';
 import { MediaPlaybackButton } from '../media-playback-button/media-playback-button.component';
 import { MediaCoverPicture } from '../media-cover-picture/media-cover-picture.component';
+import { Text } from '../text/text.component';
 
 import styles from './media-collection-item.component.css';
 
@@ -119,7 +120,9 @@ export function MediaCollectionItem(props: MediaCollectionItemProps) {
         )}
         <div className={cx('collection-item-section', 'collection-item-info')}>
           <div className={cx('collection-item-info-title')}>
-            {mediaItem.name}
+            <Text>
+              {mediaItem.name}
+            </Text>
           </div>
           {subtitle && (
             <div className={cx('collection-item-info-subtitle')}>

--- a/src/components/media-player/media-player-info.component.tsx
+++ b/src/components/media-player/media-player-info.component.tsx
@@ -59,6 +59,7 @@ export function MediaPlayerInfo() {
           onContextMenu={handleContextMenu}
         />
         <MediaTrackInfo
+          marquee
           mediaTrack={mediaPlaybackCurrentMediaTrack}
           className={cx('media-player-track-info-container')}
           onContextMenu={handleContextMenu}

--- a/src/components/media-playlist-context-menu/media-playlist-context-menu.component.tsx
+++ b/src/components/media-playlist-context-menu/media-playlist-context-menu.component.tsx
@@ -13,6 +13,7 @@ import { I18nService, MediaCollectionService, MediaPlaylistService } from '../..
 import { MediaLibraryPlaylistDuplicateTracksError } from '../../services/media-playlist.service';
 
 import { Icon } from '../icon/icon.component';
+import { Text } from '../text/text.component';
 import { TextInput } from '../text-input/text-input.component';
 import { MediaPlaylistDeleteModal } from '../media-playlist-delete-modal/media-playlist-delete-modal.component';
 import { MediaPlaylistEditModal } from '../media-playlist-edit-modal/media-playlist-edit-modal.component';
@@ -180,16 +181,22 @@ export function MediaPlaylistContextMenu(props: MediaPlaylistContextMenuProps) {
             {I18nService.getString('label_playlists_empty')}
           </Item>
         )}
-        {mediaPlaylistsToShow.map(mediaPlaylist => (
-          <Item
-            key={mediaPlaylist.id}
-            id={MediaPlaylistContextMenuItemAction.AddToPlaylist}
-            onClick={handleMenuItemClick}
-            data={{ mediaPlaylistId: mediaPlaylist.id }}
-          >
-            {mediaPlaylist.name}
-          </Item>
-        ))}
+        {/* react contextify does not have inbuilt support for handling scroll, so this is being set manually for the list */}
+        <div className="app-scrollable" style={{ maxHeight: 'var(--context-menu-max-overflow-height)' }}>
+          {mediaPlaylistsToShow.map(mediaPlaylist => (
+            <Item
+              style={{ maxWidth: 'var(--context-menu-max-overflow-width)', overflowY: 'hidden' }}
+              key={mediaPlaylist.id}
+              id={MediaPlaylistContextMenuItemAction.AddToPlaylist}
+              onClick={handleMenuItemClick}
+              data={{ mediaPlaylistId: mediaPlaylist.id }}
+            >
+              <Text>
+                {mediaPlaylist.name}
+              </Text>
+            </Item>
+          ))}
+        </div>
       </>
     );
   }

--- a/src/components/media-track-info/media-track-info.component.css
+++ b/src/components/media-track-info/media-track-info.component.css
@@ -24,7 +24,6 @@
   overflow: hidden;
 }
 
-
 .media-track-album-link,
 .media-track-artist-link {
   font-size: inherit;

--- a/src/components/media-track-info/media-track-info.component.css
+++ b/src/components/media-track-info/media-track-info.component.css
@@ -2,10 +2,10 @@
   display: flex;
   flex-flow: column;
   align-items: flex-start;
-  white-space: nowrap;
-  overflow: hidden;
+  overflow: visible;
   padding: var(--selectable-focus-ring-size); /* this is to not clip focus ring */
   gap: 5px;
+  min-width: 0;
 }
 
 .media-track-info-title {
@@ -17,6 +17,13 @@
   font-size: 13px;
   color: var(--text-dark-color);
 }
+
+.media-track-info-title,
+.media-track-info-subtitle {
+  max-width: 100%;
+  overflow: hidden;
+}
+
 
 .media-track-album-link,
 .media-track-artist-link {

--- a/src/components/media-track-info/media-track-info.component.tsx
+++ b/src/components/media-track-info/media-track-info.component.tsx
@@ -6,7 +6,8 @@ import { IMediaArtist, IMediaTrack } from '../../interfaces';
 import { StringUtils, withSeparator } from '../../utils';
 
 import { RouterLink } from '../router-link/router-link.component';
-import { Text } from '../text/text.component';
+import { Text, TextProps } from '../text/text.component';
+import { TextMarquee, TextMarqueeProps } from '../text/text-marquee.component';
 
 import styles from './media-track-info.component.css';
 
@@ -18,11 +19,28 @@ function MediaArtistLinkSeparator() {
   );
 }
 
+function MediaText(props: {
+  marquee?: boolean;
+} & (TextProps | TextMarqueeProps)) {
+  const { marquee, ...rest } = props;
+
+  if (marquee) {
+    return (
+      <TextMarquee {...rest}/>
+    );
+  }
+
+  return (
+    <Text {...rest}/>
+  );
+}
+
 export function MediaTrackAlbumLink(props: {
-  mediaTrack: IMediaTrack,
-  onContextMenu?: (e: React.MouseEvent) => void,
+  mediaTrack: IMediaTrack;
+  onContextMenu?: (e: React.MouseEvent) => void;
+  marquee?: boolean;
 }) {
-  const { mediaTrack, onContextMenu } = props;
+  const { mediaTrack, onContextMenu, marquee } = props;
 
   return (
     <RouterLink
@@ -33,34 +51,34 @@ export function MediaTrackAlbumLink(props: {
       className={cx('media-track-album-link', 'app-nav-link')}
       onContextMenu={onContextMenu}
     >
-      <Text>
+      <MediaText marquee={marquee}>
         {mediaTrack.track_name}
-      </Text>
+      </MediaText>
     </RouterLink>
   );
 }
 
 export function MediaTrackName(props: {
-  mediaTrack: IMediaTrack,
-  onContextMenu?: (e: React.MouseEvent) => void,
+  mediaTrack: IMediaTrack;
+  onContextMenu?: (e: React.MouseEvent) => void;
+  marquee?: boolean;
 }) {
-  const { mediaTrack, onContextMenu } = props;
+  const { mediaTrack, onContextMenu, marquee } = props;
 
   return (
     <div className={cx('media-track-name')} onContextMenu={onContextMenu}>
-      <Text>
+      <MediaText marquee={marquee}>
         {mediaTrack.track_name}
-      </Text>
+      </MediaText>
     </div>
   );
 }
 
 export function MediaArtistLink(props: {
-  mediaArtist: IMediaArtist,
+  mediaArtist: IMediaArtist;
+  marquee?: boolean;
 }) {
-  const {
-    mediaArtist,
-  } = props;
+  const { mediaArtist, marquee } = props;
 
   return (
     <RouterLink
@@ -70,17 +88,18 @@ export function MediaArtistLink(props: {
       })}
       className={cx('media-track-artist-link', 'app-nav-link')}
     >
-      <Text>
+      <MediaText marquee={marquee}>
         {mediaArtist.artist_name}
-      </Text>
+      </MediaText>
     </RouterLink>
   );
 }
 
 export function MediaArtistLinks(props: {
-  mediaArtists: IMediaArtist[],
+  mediaArtists: IMediaArtist[];
+  marquee?: boolean;
 }) {
-  const { mediaArtists } = props;
+  const { mediaArtists, marquee } = props;
 
   return (
     withSeparator(
@@ -89,6 +108,7 @@ export function MediaArtistLinks(props: {
         <MediaArtistLink
           key={mediaArtist.id}
           mediaArtist={mediaArtist}
+          marquee={marquee}
         />
       ),
       <MediaArtistLinkSeparator/>,
@@ -97,16 +117,18 @@ export function MediaArtistLinks(props: {
 }
 
 export function MediaTrackInfo(props: {
-  mediaTrack: IMediaTrack,
-  disableAlbumLink?: boolean,
-  className?: string,
-  onContextMenu?: (e: React.MouseEvent) => void,
+  mediaTrack: IMediaTrack;
+  disableAlbumLink?: boolean;
+  className?: string;
+  onContextMenu?: (e: React.MouseEvent) => void;
+  marquee?: boolean;
 }) {
   const {
     mediaTrack,
     disableAlbumLink = false,
     className,
     onContextMenu,
+    marquee,
   } = props;
 
   return (
@@ -116,12 +138,14 @@ export function MediaTrackInfo(props: {
           disableAlbumLink
             ? (
               <MediaTrackName
+                marquee={marquee}
                 mediaTrack={mediaTrack}
                 onContextMenu={onContextMenu}
               />
             )
             : (
               <MediaTrackAlbumLink
+                marquee={marquee}
                 mediaTrack={mediaTrack}
                 onContextMenu={onContextMenu}
               />
@@ -129,7 +153,10 @@ export function MediaTrackInfo(props: {
         }
       </div>
       <div className={cx('media-track-info-subtitle')}>
-        <MediaArtistLinks mediaArtists={mediaTrack.track_artists}/>
+        <MediaArtistLinks
+          marquee={marquee}
+          mediaArtists={mediaTrack.track_artists}
+        />
       </div>
     </div>
   );

--- a/src/components/media-track-info/media-track-info.component.tsx
+++ b/src/components/media-track-info/media-track-info.component.tsx
@@ -6,6 +6,7 @@ import { IMediaArtist, IMediaTrack } from '../../interfaces';
 import { StringUtils, withSeparator } from '../../utils';
 
 import { RouterLink } from '../router-link/router-link.component';
+import { Text } from '../text/text.component';
 
 import styles from './media-track-info.component.css';
 
@@ -32,7 +33,9 @@ export function MediaTrackAlbumLink(props: {
       className={cx('media-track-album-link', 'app-nav-link')}
       onContextMenu={onContextMenu}
     >
-      {mediaTrack.track_name}
+      <Text>
+        {mediaTrack.track_name}
+      </Text>
     </RouterLink>
   );
 }
@@ -45,7 +48,9 @@ export function MediaTrackName(props: {
 
   return (
     <div className={cx('media-track-name')} onContextMenu={onContextMenu}>
-      {mediaTrack.track_name}
+      <Text>
+        {mediaTrack.track_name}
+      </Text>
     </div>
   );
 }
@@ -65,12 +70,14 @@ export function MediaArtistLink(props: {
       })}
       className={cx('media-track-artist-link', 'app-nav-link')}
     >
-      {mediaArtist.artist_name}
+      <Text>
+        {mediaArtist.artist_name}
+      </Text>
     </RouterLink>
   );
 }
 
-export function MediaArtistLinksComponent(props: {
+export function MediaArtistLinks(props: {
   mediaArtists: IMediaArtist[],
 }) {
   const { mediaArtists } = props;
@@ -122,7 +129,7 @@ export function MediaTrackInfo(props: {
         }
       </div>
       <div className={cx('media-track-info-subtitle')}>
-        <MediaArtistLinksComponent mediaArtists={mediaTrack.track_artists}/>
+        <MediaArtistLinks mediaArtists={mediaTrack.track_artists}/>
       </div>
     </div>
   );

--- a/src/components/media-track/media-track.component.css
+++ b/src/components/media-track/media-track.component.css
@@ -37,7 +37,9 @@
 }
 
 .media-track-section.info {
-  flex-grow: 1;
+  flex: 1 1 auto; /* take remaining horizontal space and be allowed to shrink */
+  min-width: 0;
+  overflow: visible; /* children handle their own overflow */
 }
 
 .media-track-section.end {

--- a/src/components/text/text-clamp.component.tsx
+++ b/src/components/text/text-clamp.component.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+
+import styles from './text.component.css';
+import { TextProps } from './text.component';
+
+const cx = classNames.bind(styles);
+
+export type TextClampProps = {
+  lines?: number;
+} & TextProps;
+
+export function TextClamp(props: TextClampProps) {
+  const {
+    children,
+    lines = 3,
+    style,
+    ...rest
+  } = props;
+
+  return (
+    <span
+      {...rest}
+      className={cx('text-clamp')}
+      style={{
+        WebkitLineClamp: lines,
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/text/text-marquee.component.tsx
+++ b/src/components/text/text-marquee.component.tsx
@@ -1,0 +1,70 @@
+import classNames from 'classnames/bind';
+import React from 'react';
+
+import { Text, TextProps } from './text.component';
+
+import styles from './text.component.css';
+
+const cx = classNames.bind(styles);
+
+export type TextMarqueeProps = {
+  speed?: number; // in pixels
+  delay?: number; // in seconds
+} & TextProps;
+
+export function TextMarquee(props: TextMarqueeProps) {
+  const {
+    speed = 30,
+    delay = 0,
+    children,
+    ...rest
+  } = props;
+
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const textRef = React.useRef<HTMLSpanElement>(null);
+  const [isOverflowing, setIsOverflowing] = React.useState(false);
+  const [animationDuration, setAnimationDuration] = React.useState(0);
+  const [textWidth, setTextWidth] = React.useState(0);
+
+  React.useEffect(() => {
+    const container = containerRef.current;
+    const text = textRef.current;
+    if (container && text) {
+      const containerWidth = container.clientWidth;
+      const textScrollWidth = text.scrollWidth;
+      const overflow = textScrollWidth > containerWidth;
+      setIsOverflowing(overflow);
+      setTextWidth(textScrollWidth);
+
+      if (overflow) {
+        setAnimationDuration((textScrollWidth + containerWidth) / speed); // seconds
+      }
+    }
+  }, [
+    children,
+    speed,
+  ]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cx('text-marquee-container')}
+    >
+      <Text
+        ref={textRef}
+        {...rest}
+        className={cx('text-marquee', {
+          active: isOverflowing,
+        })}
+        style={{
+          animationDuration: `${animationDuration}s`,
+          animationDelay: `${delay}s`,
+          // @ts-ignore
+          '--marquee-width': `${textWidth}px`,
+        }}
+      >
+        {children}
+      </Text>
+    </div>
+  );
+}

--- a/src/components/text/text.component.css
+++ b/src/components/text/text.component.css
@@ -12,3 +12,33 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.text-marquee-container {
+}
+
+.text-marquee.active {
+  animation-name: marquee;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-play-state: running;
+  max-width: 100%;
+  text-overflow: clip;
+  overflow: visible;
+}
+
+.text-marquee:hover {
+  animation-play-state: paused;
+}
+
+@keyframes marquee {
+  0% {
+    transform: translateX(0);
+  }
+  15% {
+    /* duplicated keyframe to hold at start */
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(calc(-1 * var(--marquee-width)));
+  }
+}

--- a/src/components/text/text.component.css
+++ b/src/components/text/text.component.css
@@ -5,3 +5,10 @@
   text-overflow: ellipsis;
   min-width: 0; /* critical when inside flex */
 }
+
+.text-clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/components/text/text.component.css
+++ b/src/components/text/text.component.css
@@ -1,0 +1,6 @@
+.text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}

--- a/src/components/text/text.component.css
+++ b/src/components/text/text.component.css
@@ -1,6 +1,7 @@
 .text {
-  white-space: nowrap;
+  display: block; /* or inline-block depending on context */
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
-  max-width: 100%;
+  min-width: 0; /* critical when inside flex */
 }

--- a/src/components/text/text.component.tsx
+++ b/src/components/text/text.component.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+
+import styles from './text.component.css';
+
+const cx = classNames.bind(styles);
+
+export function Text(props: {
+  children?: React.ReactNode;
+}) {
+  const { children } = props;
+
+  return (
+    <span className={cx('text')}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/text/text.component.tsx
+++ b/src/components/text/text.component.tsx
@@ -5,13 +5,18 @@ import styles from './text.component.css';
 
 const cx = classNames.bind(styles);
 
-export function Text(props: {
+export type TextProps = {
   children?: React.ReactNode;
-}) {
-  const { children } = props;
+} & React.HTMLAttributes<HTMLSpanElement>;
+
+export function Text(props: TextProps) {
+  const { children, ...rest } = props;
 
   return (
-    <span className={cx('text')}>
+    <span
+      {...rest}
+      className={cx('text')}
+    >
       {children}
     </span>
   );

--- a/src/components/text/text.component.tsx
+++ b/src/components/text/text.component.tsx
@@ -9,15 +9,18 @@ export type TextProps = {
   children?: React.ReactNode;
 } & React.HTMLAttributes<HTMLSpanElement>;
 
-export function Text(props: TextProps) {
+export const Text = React.forwardRef<HTMLSpanElement, TextProps>((props, ref) => {
   const { children, ...rest } = props;
 
   return (
     <span
       {...rest}
-      className={cx('text')}
+      ref={ref}
+      className={cx('text', rest.className)}
     >
       {children}
     </span>
   );
-}
+});
+
+Text.displayName = 'Text';

--- a/src/index.global.css
+++ b/src/index.global.css
@@ -16,6 +16,8 @@
   /*context menu*/
   --context-menu-color: #b3b3b3;
   --context-menu-bg-color: #282828;
+  --context-menu-max-overflow-width: 250px;
+  --context-menu-max-overflow-height: 300px;
   /*button*/
   --button-primary-bg-color: #009233;
   --button-primary-hovered-bg-color: #007a2b;

--- a/src/pages/album/album.component.tsx
+++ b/src/pages/album/album.component.tsx
@@ -10,6 +10,7 @@ import {
   MediaTrackList,
   MediaTrackContextMenuItem,
   MediaCollectionActions,
+  TextClamp,
 } from '../../components';
 
 import { Icons, Layout } from '../../constants';
@@ -54,7 +55,9 @@ export function AlbumPage() {
               {I18nService.getString('label_album_header')}
             </div>
             <div className={cx('album-header-name')}>
-              {mediaSelectedAlbum.album_name}
+              <TextClamp>
+                {mediaSelectedAlbum.album_name}
+              </TextClamp>
             </div>
             <div className={cx('album-header-info')}>
               <MediaArtistLink mediaArtist={mediaSelectedAlbum.album_artist}/>

--- a/src/pages/artist/artist.component.tsx
+++ b/src/pages/artist/artist.component.tsx
@@ -5,9 +5,15 @@ import { isEmpty } from 'lodash';
 import classNames from 'classnames/bind';
 
 import { Icons, Layout } from '../../constants';
-import { MediaAlbums, MediaCollectionActions, MediaCoverPicture } from '../../components';
 import { RootState } from '../../reducers';
 import { I18nService, MediaCollectionService, MediaLibraryService } from '../../services';
+
+import {
+  MediaAlbums,
+  MediaCollectionActions,
+  MediaCoverPicture,
+  TextClamp,
+} from '../../components';
 
 import styles from './artist.component.css';
 
@@ -48,7 +54,9 @@ export function ArtistPage() {
               {I18nService.getString('label_artist_header')}
             </div>
             <div className={cx('artist-header-name')}>
-              {mediaSelectedArtist.artist_name}
+              <TextClamp>
+                {mediaSelectedArtist.artist_name}
+              </TextClamp>
             </div>
             <div className={cx('artist-header-info')}/>
           </div>

--- a/src/pages/playlist/playlist.component.tsx
+++ b/src/pages/playlist/playlist.component.tsx
@@ -17,6 +17,7 @@ import {
   MediaPlaylistDeleteTracksModal,
   MediaTrackContextMenuItem,
   MediaTrackList,
+  TextClamp,
 } from '../../components';
 
 import styles from './playlist.component.css';
@@ -120,7 +121,9 @@ export function PlaylistPage() {
               {I18nService.getString('label_playlist_header')}
             </div>
             <div className={cx('playlist-header-name')}>
-              {mediaSelectedPlaylist.name}
+              <TextClamp>
+                {mediaSelectedPlaylist.name}
+              </TextClamp>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description
This fixes issues with text overflow across the app

<img width="1025" height="1003" alt="Screenshot 2025-09-26 at 17 19 12" src="https://github.com/user-attachments/assets/6694cab4-ee9a-4162-865e-071cd49a4a03" />

## Tests

### Manual test cases run
- In playlist, album and artist page - Text should clip vertically upto 3 lines
- In playlist context menu, playlist name should get clipped if overflowing
- In playlist context menu, playlist list should be scrollable if the list gets too long
- In track list item, track name and artist should get clipped
- In playlist list item, playlist name should get clipped
- In media player, current playing track should have a marquee effect if name or artist name is overflowing. Should remain the same if not.
