### PR TITLE
feat: When showing playlists in context menu or on page, they should be sorted by last updated time

### DIFF
--- a/src/datastores/media-playlist.datastore.ts
+++ b/src/datastores/media-playlist.datastore.ts
@@ -19,7 +19,13 @@ class MediaPlaylistDatastore {
   }
 
   insertMediaPlaylist(mediaPlaylistInputData: DataStoreInputData<IMediaPlaylistData>): Promise<IMediaPlaylistData> {
-    return IPCService.sendAsyncMessage(IPCCommChannel.DSInsertOne, this.mediaPlaylistsDatastoreName, mediaPlaylistInputData);
+    const now = Date.now();
+
+    return IPCService.sendAsyncMessage(IPCCommChannel.DSInsertOne, this.mediaPlaylistsDatastoreName, {
+      ...mediaPlaylistInputData,
+      created_at: now,
+      updated_at: now,
+    });
   }
 
   addMediaPlaylistTracks(mediaPlaylistId: string, mediaTrackInputDataList: IMediaPlaylistTrackData[]): Promise<IMediaPlaylistData> {
@@ -30,6 +36,9 @@ class MediaPlaylistDatastore {
         tracks: {
           $each: mediaTrackInputDataList,
         },
+      },
+      $set: {
+        updated_at: Date.now(),
       },
     });
   }
@@ -44,6 +53,9 @@ class MediaPlaylistDatastore {
             $in: mediaPlaylistTrackIds,
           },
         },
+      },
+      $set: {
+        updated_at: Date.now(),
       },
     });
   }
@@ -66,7 +78,10 @@ class MediaPlaylistDatastore {
     return IPCService.sendAsyncMessage(IPCCommChannel.DSUpdateOne, this.mediaPlaylistsDatastoreName, {
       id: mediaPlaylistId,
     }, {
-      $set: mediaPlaylistUpdateData,
+      $set: {
+        ...mediaPlaylistUpdateData,
+        updated_at: Date.now(),
+      },
     });
   }
 }

--- a/src/interfaces/media.interfaces.ts
+++ b/src/interfaces/media.interfaces.ts
@@ -163,6 +163,7 @@ export interface IMediaPlaylistData {
   tracks: IMediaPlaylistTrackData[];
   cover_picture?: IMediaPicture;
   created_at: number;
+  updated_at: number;
 }
 
 export interface IMediaPlaylistTrackData extends IMediaProviderTrackData {

--- a/src/pages/playlists/playlists.component.tsx
+++ b/src/pages/playlists/playlists.component.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames/bind';
 import { useHistory } from 'react-router-dom';
 
 import { Icons, Routes } from '../../constants';
-import { RootState } from '../../reducers';
+import { selectSortedPlaylists } from '../../selectors';
 import { I18nService, MediaPlaylistService } from '../../services';
 import { StringUtils } from '../../utils';
 
@@ -48,7 +48,7 @@ function PlaylistsEmptySection() {
 }
 
 export function PlaylistsPage() {
-  const mediaPlaylists = useSelector((state: RootState) => state.mediaLibrary.mediaPlaylists);
+  const mediaPlaylists = useSelector(selectSortedPlaylists);
 
   useEffect(() => {
     MediaPlaylistService.loadMediaPlaylists();

--- a/src/reducers/media-library.reducer.ts
+++ b/src/reducers/media-library.reducer.ts
@@ -1,4 +1,4 @@
-import { omit, keyBy } from 'lodash';
+import { omit, keyBy, pullAt } from 'lodash';
 
 import { MediaLibraryActions } from '../enums';
 import { ArrayUtils, MediaUtils } from '../utils';
@@ -251,14 +251,16 @@ export default (state: MediaLibraryState = mediaLibraryInitialState, action: Med
       // data.mediaPlaylist: IMediaPlaylist - playlist need to be added
       const { mediaPlaylist } = action.data;
       const { mediaPlaylists } = state;
+      const mediaPlaylistsUpdated = [...mediaPlaylists];
       let { mediaSelectedPlaylist } = state;
 
       const mediaPlaylistIdx = mediaPlaylists.findIndex(exMediaPlaylist => mediaPlaylist.id === exMediaPlaylist.id);
-      if (mediaPlaylistIdx === -1) {
-        ArrayUtils.updateSortedArray<IMediaPlaylist>(mediaPlaylists, mediaPlaylist, MediaUtils.mediaPlaylistComparator);
-      } else {
-        mediaPlaylists[mediaPlaylistIdx] = mediaPlaylist;
+      if (mediaPlaylistIdx !== -1) {
+        // remove and let the flow add again
+        pullAt(mediaPlaylistsUpdated, mediaPlaylistIdx);
       }
+
+      mediaPlaylistsUpdated.push(mediaPlaylist);
 
       if (mediaSelectedPlaylist?.id === mediaPlaylist.id) {
         mediaSelectedPlaylist = mediaPlaylist;
@@ -266,7 +268,7 @@ export default (state: MediaLibraryState = mediaLibraryInitialState, action: Med
 
       return {
         ...state,
-        mediaPlaylists,
+        mediaPlaylists: mediaPlaylistsUpdated,
         mediaSelectedPlaylist,
       };
     }

--- a/src/selectors/media-library.selector.ts
+++ b/src/selectors/media-library.selector.ts
@@ -37,3 +37,10 @@ export const makeSelectIsCollectionPinned = (input?: IMediaPinnedItemInputData) 
   [selectMediaPinnedItemsRecord],
   mediaPinnedItemsRecord => !!input && !!mediaPinnedItemsRecord[MediaUtils.getPinnedItemKeyFromInput(input)],
 );
+
+export const selectMediaPlaylists = (state: RootState) => state.mediaLibrary.mediaPlaylists;
+
+export const selectSortedPlaylists = createSelector(
+  [selectMediaPlaylists],
+  mediaPlaylists => MediaUtils.sortMediaPlaylists(mediaPlaylists),
+);

--- a/src/services/media-playlist.service.ts
+++ b/src/services/media-playlist.service.ts
@@ -141,7 +141,6 @@ class MediaPlaylistService {
     const inputData: DataStoreInputData<IMediaPlaylistData> = _.defaults(mediaPlaylistInputData, {
       name: await this.getDefaultNewPlaylistName(),
       tracks: [],
-      created_at: Date.now(),
     });
     inputData.tracks = inputData.tracks.map(trackInputData => this.buildMediaPlaylistTrackFromInput(trackInputData));
 

--- a/src/types/datastore.types.ts
+++ b/src/types/datastore.types.ts
@@ -32,6 +32,6 @@ export type DataStoreQueryData<T> = {
   limit?: number,
 };
 
-export type DataStoreInputData<T = any> = Omit<T, 'id'>;
+export type DataStoreInputData<T = any> = Omit<T, 'id' | 'created_at' | 'updated_at'>;
 
 export type DataStoreUpdateData<T = any> = Partial<Omit<T, 'id' | 'created_at'>>;

--- a/src/utils/media.utils.ts
+++ b/src/utils/media.utils.ts
@@ -46,7 +46,7 @@ export function mediaPlaylistComparator(
   mediaPlaylistA: IMediaPlaylist,
   mediaPlaylistB: IMediaPlaylist,
 ) {
-  return mediaPlaylistA.created_at > mediaPlaylistB.created_at ? -1 : 1;
+  return mediaPlaylistA.updated_at > mediaPlaylistB.updated_at ? -1 : 1;
 }
 
 export function mediaLikedTracksComparator(


### PR DESCRIPTION
## Description
This adds support for sorting playlists based on `updated_at` timestamp

## Tests

### Manual test cases run
- When new track(s) is/are added to the playlist, it is shown on top on playlists page
- When track(s) is/are removed from the playlist, it is shown on top on playlists page
- When playlist is renamed, it is shown on top on playlists page
- Same rules apply on playlists in context menu
