### PR TITLE
fix: Fix duplicate playback issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@types/bluebird-global": "^3.5.12",
+    "@types/howler": "^2.2.1",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^26.0.15",

--- a/src/providers/media-local/media-local-playback.model.ts
+++ b/src/providers/media-local/media-local-playback.model.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { Howl } from 'howler';
 
 import { IMediaPlayback, IMediaPlaybackOptions } from '../../interfaces';
@@ -10,7 +9,7 @@ const debug = require('debug')('app:provider:media_local:media_playback');
 
 export class MediaLocalPlayback implements IMediaPlayback {
   private readonly mediaTrack: IMediaLocalTrack;
-  private readonly mediaPlaybackLocalAudio: any;
+  private readonly mediaPlaybackLocalAudio: Howl;
   private mediaPlaybackId: number | undefined;
   private mediaPlaybackEnded = false;
 
@@ -41,7 +40,8 @@ export class MediaLocalPlayback implements IMediaPlayback {
 
       // play returns a unique sound ID that can be passed
       // into any method on Howl to control that specific sound
-      this.mediaPlaybackId = this.mediaPlaybackLocalAudio.play();
+      // important - pass down the stored id if resuming playback
+      this.mediaPlaybackId = this.mediaPlaybackLocalAudio.play(this.mediaPlaybackId);
       debug('playing track id - %s, playback id - %d', this.mediaTrack.id, this.mediaPlaybackId);
     });
   }
@@ -51,7 +51,7 @@ export class MediaLocalPlayback implements IMediaPlayback {
   }
 
   checkIfPlaying(): boolean {
-    return this.mediaPlaybackLocalAudio.playing();
+    return this.mediaPlaybackLocalAudio.playing(this.mediaPlaybackId);
   }
 
   checkIfEnded(): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,6 +2299,11 @@
   dependencies:
     hoist-non-react-statics "^3.3.0"
 
+"@types/howler@^2.2.1":
+  version "2.2.12"
+  resolved "https://registry.yarnpkg.com/@types/howler/-/howler-2.2.12.tgz#078d20787911f6e3e871a0e93a23832e13abaa59"
+  integrity sha512-hy769UICzOSdK0Kn1FBk4gN+lswcj1EKRkmiDtMkUGvFfYJzgaDXmVXkSShS2m89ERAatGIPnTUlp2HhfkVo5g==
+
 "@types/http-cache-semantics@*":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"


### PR DESCRIPTION
## Description
This fixes issue with local media playback where calling `.play()` multiple simultaneously will play duplicate track. This was fixed via passing playback id when calling `.play()`.

## Tests

### Manual test cases run
When play is called multiple times, it should ignore subsequent calls and keep playing the track
