### PR TITLE
fix: Fix pinned item sorting issue

### DIFF
--- a/src/main/modules/datastore.module.ts
+++ b/src/main/modules/datastore.module.ts
@@ -65,7 +65,7 @@ export class DatastoreModule implements IAppModule {
     try {
       fs.unlinkSync(datastoreFilename);
       debug('removeDatastore - datastore file was removed successfully');
-    } catch (error) {
+    } catch (error: any) {
       if (error.code === 'ENOENT') {
         debug('removeDatastore - datastore file does not exists');
       } else {
@@ -118,10 +118,11 @@ export class DatastoreModule implements IAppModule {
       'skip',
       'limit',
     ], (key) => {
-      const value = _.get(datastoreName, key);
+      const value = _.get(datastoreQueryDoc, key);
 
       if (!_.isNil(value)) {
-        _.set(cursor, key, value);
+        // @ts-ignore
+        cursor[key]?.(value);
       }
     });
 


### PR DESCRIPTION
## Description
This fixes issue with pinned item sorting when new item was being added. The datastore `find` call was not accepting/configuring the cursor correctly, causing the params like `sort` and `limit` not to work properly.

## Tests

### Manual test cases run
- When adding new pinned item it should have a correct `order`