### PR TITLE
feat: Add support for mtime based syncing

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -84,5 +84,6 @@
   "tooltip_pin_collection": "Pin {collectionType}",
   "tooltip_unpin_collection": "Unpin {collectionType}",
   "tooltip_settings_sync_file_scanned": "Files Scanned",
+  "tooltip_settings_sync_file_added": "Files Added",
   "tooltip_settings_sync_time_taken": "Time Taken"
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -66,6 +66,7 @@
   "message_track_disliked": "Removed from Liked Songs",
   "message_tracks_liked": "Added to Liked Songs",
   "message_tracks_disliked": "Removed from Liked Songs",
+  "message_sync_finished": "Sync completed, added {tracksAddedCount} tracks",
   "placeholder_playlist_context_menu_search_input": "Find a playlist",
   "placeholder_search_input": "What do you want to play?",
   "search_result_heading_all": "All",
@@ -83,7 +84,7 @@
   "tooltip_track_dislike": "Remove from Liked Songs",
   "tooltip_pin_collection": "Pin {collectionType}",
   "tooltip_unpin_collection": "Unpin {collectionType}",
-  "tooltip_settings_sync_file_scanned": "Files Scanned",
+  "tooltip_settings_sync_file_found": "Files Found",
   "tooltip_settings_sync_file_added": "Files Added",
   "tooltip_settings_sync_time_taken": "Time Taken"
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -85,6 +85,6 @@
   "tooltip_pin_collection": "Pin {collectionType}",
   "tooltip_unpin_collection": "Unpin {collectionType}",
   "tooltip_settings_sync_file_found": "Files Found",
-  "tooltip_settings_sync_file_added": "Files Added",
+  "tooltip_settings_sync_file_processed": "Files Processed",
   "tooltip_settings_sync_time_taken": "Time Taken"
 }

--- a/src/datastores/media-album.datastore.ts
+++ b/src/datastores/media-album.datastore.ts
@@ -49,6 +49,12 @@ class MediaAlbumDatastore {
     });
   }
 
+  updateMediaAlbum(mediaAlbumFilterData: DataStoreFilterData<IMediaAlbumData>, mediaAlbumUpdateData: DataStoreUpdateData<IMediaAlbumData>): Promise<IMediaAlbumData | undefined> {
+    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpdateOne, this.mediaAlbumDatastoreName, mediaAlbumFilterData, {
+      $set: mediaAlbumUpdateData,
+    });
+  }
+
   insertMediaAlbum(mediaAlbumInputData: DataStoreInputData<IMediaAlbumData>): Promise<IMediaAlbumData> {
     return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSInsertOne, this.mediaAlbumDatastoreName, mediaAlbumInputData);
   }

--- a/src/datastores/media-album.datastore.ts
+++ b/src/datastores/media-album.datastore.ts
@@ -57,11 +57,8 @@ class MediaAlbumDatastore {
     return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSRemove, this.mediaAlbumDatastoreName, mediaAlbumFilterData);
   }
 
-  upsertMediaAlbum(input: DataStoreInputData<IMediaAlbumData>): Promise<IMediaAlbumData> {
-    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpsertOne, this.mediaAlbumDatastoreName, {
-      provider: input.provider,
-      provider_id: input.provider_id,
-    }, input);
+  upsertMediaAlbum(mediaAlbumFilterData: DataStoreFilterData<IMediaAlbumData>, mediaAlbumInputData: DataStoreInputData<IMediaAlbumData>): Promise<IMediaAlbumData> {
+    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpsertOne, this.mediaAlbumDatastoreName, mediaAlbumFilterData, mediaAlbumInputData);
   }
 }
 

--- a/src/datastores/media-artist.datastore.ts
+++ b/src/datastores/media-artist.datastore.ts
@@ -49,6 +49,12 @@ class MediaArtistDatastore {
     });
   }
 
+  updateArtists(mediaArtistFilterData: DataStoreFilterData<IMediaArtistData>, mediaArtistUpdateData: DataStoreUpdateData<IMediaArtistData>): Promise<IMediaArtistData[]> {
+    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpdate, this.mediaArtistDatastoreName, mediaArtistFilterData, {
+      $set: mediaArtistUpdateData,
+    });
+  }
+
   insertMediaArtist(mediaArtistInputData: DataStoreInputData<IMediaArtistData>): Promise<IMediaArtistData> {
     return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSInsertOne, this.mediaArtistDatastoreName, mediaArtistInputData);
   }

--- a/src/datastores/media-artist.datastore.ts
+++ b/src/datastores/media-artist.datastore.ts
@@ -57,11 +57,8 @@ class MediaArtistDatastore {
     return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSRemove, this.mediaArtistDatastoreName, mediaArtistFilterData);
   }
 
-  upsertMediaArtist(input: DataStoreInputData<IMediaArtistData>): Promise<IMediaArtistData> {
-    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpsertOne, this.mediaArtistDatastoreName, {
-      provider: input.provider,
-      provider_id: input.provider_id,
-    }, input);
+  upsertMediaArtist(mediaArtistFilterData: DataStoreFilterData<IMediaArtistData>, mediaArtistInputData: DataStoreInputData<IMediaArtistData>): Promise<IMediaArtistData> {
+    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpsertOne, this.mediaArtistDatastoreName, mediaArtistFilterData, mediaArtistInputData);
   }
 }
 

--- a/src/datastores/media-track.datastore.ts
+++ b/src/datastores/media-track.datastore.ts
@@ -35,10 +35,8 @@ class MediaTrackDatastore {
     });
   }
 
-  updateTrackById(mediaTrackId: string, mediaTrackUpdateData: DataStoreUpdateData<IMediaTrackData>): Promise<IMediaTrackData> {
-    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpdateOne, this.mediaTrackDatastoreName, {
-      id: mediaTrackId,
-    }, {
+  updateMediaTrack(mediaTrackFilterData: DataStoreFilterData<IMediaTrackData>, mediaTrackUpdateData: DataStoreUpdateData<IMediaTrackData>): Promise<IMediaTrackData | undefined> {
+    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpdateOne, this.mediaTrackDatastoreName, mediaTrackFilterData, {
       $set: mediaTrackUpdateData,
     });
   }
@@ -51,11 +49,8 @@ class MediaTrackDatastore {
     return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSRemove, this.mediaTrackDatastoreName, mediaTrackFilterData);
   }
 
-  upsertMediaTrack(input: DataStoreInputData<IMediaTrackData>): Promise<IMediaTrackData> {
-    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpsertOne, this.mediaTrackDatastoreName, {
-      provider: input.provider,
-      provider_id: input.provider_id,
-    }, input);
+  upsertMediaTrack(mediaTrackFilterData: DataStoreFilterData<IMediaTrackData>, mediaTrackInputData: DataStoreInputData<IMediaTrackData>): Promise<IMediaTrackData> {
+    return IPCRenderer.sendAsyncMessage(IPCCommChannel.DSUpsertOne, this.mediaTrackDatastoreName, mediaTrackFilterData, mediaTrackInputData);
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,16 @@ import { App } from './app/app.component';
 const isDebug = process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true';
 const isProd = process.env.NODE_ENV === 'production';
 
+if (isDebug) {
+  // to enable stack traces in promises
+  Promise.config({
+    longStackTraces: true,
+    warnings: true,
+    cancellation: true,
+    monitoring: true,
+  });
+}
+
 // @ts-ignore
 global.Promise = Promise;
 

--- a/src/modules/datastore/module.ts
+++ b/src/modules/datastore/module.ts
@@ -51,6 +51,7 @@ export class DatastoreModule implements IAppModule {
     IPCMain.addAsyncMessageHandler(IPCCommChannel.DSFind, this.find, this);
     IPCMain.addAsyncMessageHandler(IPCCommChannel.DSFindOne, this.findOne, this);
     IPCMain.addAsyncMessageHandler(IPCCommChannel.DSInsertOne, this.insertOne, this);
+    IPCMain.addAsyncMessageHandler(IPCCommChannel.DSUpdate, this.update, this);
     IPCMain.addAsyncMessageHandler(IPCCommChannel.DSUpdateOne, this.updateOne, this);
     IPCMain.addAsyncMessageHandler(IPCCommChannel.DSRemove, this.remove, this);
     IPCMain.addAsyncMessageHandler(IPCCommChannel.DSRemoveOne, this.removeOne, this);
@@ -144,7 +145,18 @@ export class DatastoreModule implements IAppModule {
     });
   }
 
-  private async updateOne(datastoreName: string, datastoreFindDoc: DataStoreFilterData, datastoreUpdateOneDoc: object): Promise<void> {
+  private async update(datastoreName: string, datastoreFindDoc: DataStoreFilterData, datastoreUpdateDoc: object): Promise<any> {
+    const datastore = this.getDatastore(datastoreName);
+
+    // important - id is reserved for datastore
+    return datastore.update(datastoreFindDoc, _.omit(datastoreUpdateDoc, ['$set.id', '$unset.id']), {
+      multi: true,
+      upsert: false,
+      returnUpdatedDocs: true,
+    });
+  }
+
+  private async updateOne(datastoreName: string, datastoreFindDoc: DataStoreFilterData, datastoreUpdateOneDoc: object): Promise<any> {
     const datastore = this.getDatastore(datastoreName);
 
     // important - id is reserved for datastore

--- a/src/modules/file-system/module.ts
+++ b/src/modules/file-system/module.ts
@@ -84,7 +84,7 @@ export class FileSystemModule implements IAppModule {
 
     const walker = walkStream(directory, {
       followSymbolicLinks: false,
-      stats: false,
+      stats: true,
       throwErrorOnBrokenSymbolicLink: false,
       entryFilter,
     });
@@ -95,6 +95,10 @@ export class FileSystemModule implements IAppModule {
         batch.push({
           path: entry.path,
           name: path.basename(entry.path),
+          stats: {
+            mtime: entry.stats?.mtimeMs,
+            size: entry.stats?.size,
+          },
         });
 
         if (batch.length >= batchSize) {

--- a/src/modules/file-system/types.ts
+++ b/src/modules/file-system/types.ts
@@ -10,6 +10,10 @@ export type FSReadDirectoryParams = {
 export type FSFile = {
   path: string;
   name: string;
+  stats?: {
+    mtime?: number;
+    size?: number;
+  },
 };
 
 export type FSSelectFileOptions = {

--- a/src/modules/ipc/enums.ts
+++ b/src/modules/ipc/enums.ts
@@ -16,6 +16,7 @@ export enum IPCCommChannel {
   DSFind = 'ds:find',
   DSFindOne = 'ds:find_one',
   DSInsertOne = 'ds:insert_one',
+  DSUpdate = 'ds:update',
   DSUpdateOne = 'ds:update_one',
   DSRemoveOne = 'ds:remove_one',
   DSRemove = 'ds:remove',

--- a/src/pages/album/album.component.tsx
+++ b/src/pages/album/album.component.tsx
@@ -13,9 +13,15 @@ import {
   TextClamp,
 } from '../../components';
 
+import {
+  I18nService,
+  MediaAlbumService,
+  MediaCollectionService,
+  MediaTrackService,
+} from '../../services';
+
 import { Icons, Layout } from '../../constants';
 import { RootState } from '../../reducers';
-import { I18nService, MediaCollectionService, MediaLibraryService } from '../../services';
 
 import styles from './album.component.css';
 
@@ -27,9 +33,9 @@ export function AlbumPage() {
   const mediaSelectedAlbumTracks = useSelector((state: RootState) => state.mediaLibrary.mediaSelectedAlbumTracks);
 
   useEffect(() => {
-    MediaLibraryService.loadMediaAlbum(albumId);
+    MediaTrackService.loadMediaAlbumTracks(albumId);
 
-    return () => MediaLibraryService.unloadMediaAlbum();
+    return () => MediaAlbumService.unloadMediaAlbum();
   }, [
     albumId,
   ]);

--- a/src/pages/album/album.component.tsx
+++ b/src/pages/album/album.component.tsx
@@ -10,6 +10,7 @@ import {
   MediaTrackList,
   MediaTrackContextMenuItem,
   MediaCollectionActions,
+  Text,
   TextClamp,
 } from '../../components';
 
@@ -66,7 +67,9 @@ export function AlbumPage() {
               </TextClamp>
             </div>
             <div className={cx('album-header-info')}>
-              <MediaArtistLink mediaArtist={mediaSelectedAlbum.album_artist}/>
+              <Text>
+                <MediaArtistLink mediaArtist={mediaSelectedAlbum.album_artist}/>
+              </Text>
             </div>
           </div>
         </div>

--- a/src/pages/albums/albums.component.tsx
+++ b/src/pages/albums/albums.component.tsx
@@ -3,13 +3,13 @@ import { useSelector } from 'react-redux';
 
 import { MediaAlbums } from '../../components';
 import { RootState } from '../../reducers';
-import { MediaLibraryService } from '../../services';
+import { MediaAlbumService } from '../../services';
 
 export function AlbumsPage() {
   const { mediaAlbums } = useSelector((state: RootState) => state.mediaLibrary);
 
   useEffect(() => {
-    MediaLibraryService.loadMediaAlbums();
+    MediaAlbumService.loadMediaAlbums();
   }, []);
 
   return (

--- a/src/pages/artist/artist.component.tsx
+++ b/src/pages/artist/artist.component.tsx
@@ -4,9 +4,12 @@ import { useSelector } from 'react-redux';
 import { isEmpty } from 'lodash';
 import classNames from 'classnames/bind';
 
-import { Icons, Layout } from '../../constants';
-import { RootState } from '../../reducers';
-import { I18nService, MediaCollectionService, MediaLibraryService } from '../../services';
+import {
+  I18nService,
+  MediaAlbumService,
+  MediaArtistService,
+  MediaCollectionService,
+} from '../../services';
 
 import {
   MediaAlbums,
@@ -14,6 +17,9 @@ import {
   MediaCoverPicture,
   TextClamp,
 } from '../../components';
+
+import { Icons, Layout } from '../../constants';
+import { RootState } from '../../reducers';
 
 import styles from './artist.component.css';
 
@@ -26,9 +32,9 @@ export function ArtistPage() {
   const mediaSelectedArtistAlbums = useSelector((state: RootState) => state.mediaLibrary.mediaSelectedArtistAlbums);
 
   useEffect(() => {
-    MediaLibraryService.loadMediaArtist(artistId);
+    MediaAlbumService.loadMediaArtistAlbums(artistId);
 
-    return () => MediaLibraryService.unloadMediaArtist();
+    return () => MediaArtistService.unloadMediaArtist();
   }, [
     artistId,
   ]);

--- a/src/pages/artists/artists.component.tsx
+++ b/src/pages/artists/artists.component.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { RootState } from '../../reducers';
-import { MediaLibraryService } from '../../services';
 import { MediaArtists } from '../../components';
+import { RootState } from '../../reducers';
+import { MediaArtistService } from '../../services';
 
 export function ArtistsPage() {
   const { mediaArtists } = useSelector((state: RootState) => state.mediaLibrary);
 
   useEffect(() => {
-    MediaLibraryService.loadMediaArtists();
+    MediaArtistService.loadMediaArtists();
   }, []);
 
   return (

--- a/src/persistors/media-player.persistor.ts
+++ b/src/persistors/media-player.persistor.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { IAppStatePersistor, IMediaQueueTrack } from '../interfaces';
-import { MediaLibraryService, MediaPlayerService } from '../services';
+import { MediaPlayerService, MediaTrackService } from '../services';
 
 import { MediaPlayerState } from '../reducers/media-player.reducer';
 import { MediaEnums } from '../enums';
@@ -66,7 +66,7 @@ export default class MediaPlayerPersistor implements IAppStatePersistor {
     // load media queue
     // important - load tracks directly to retain original queue info and shuffle order
     const mediaQueueTracks = await Promise.reduce(mediaTracks, async (mediaTracksDeserialized: IMediaQueueTrack[], mediaTrackSerialized) => {
-      const mediaTrack = await MediaLibraryService.getMediaTrack(mediaTrackSerialized.id);
+      const mediaTrack = await MediaTrackService.getMediaTrack(mediaTrackSerialized.id);
 
       if (mediaTrack) {
         mediaTracksDeserialized.push({

--- a/src/providers/media-local/media-local-library.service.ts
+++ b/src/providers/media-local/media-local-library.service.ts
@@ -206,7 +206,7 @@ class MediaLocalLibraryService implements IMediaLibraryService {
 
           // update stats
           mediaLocalStore.dispatch({
-            type: MediaLocalStateActionType.IncrementDirectorySyncFilesAdded,
+            type: MediaLocalStateActionType.IncrementDirectorySyncFilesProcessed,
             data: {
               directory,
               count: 1,

--- a/src/providers/media-local/media-local-library.service.ts
+++ b/src/providers/media-local/media-local-library.service.ts
@@ -120,17 +120,20 @@ class MediaLocalLibraryService implements IMediaLibraryService {
         });
 
         // notification
-        const { syncFilesFoundCount, syncFilesAddedCount } = mediaLocalStore.getState();
+        const { syncFilesFoundCount, syncFilesProcessedCount, syncFilesAddedCount } = mediaLocalStore.getState();
         if (syncFilesAddedCount > 0) {
           NotificationService.showMessage(I18nService.getString('message_sync_finished', {
             tracksAddedCount: syncFilesAddedCount,
           }));
         }
 
-        debug('syncMediaTracks - finished sync, took - %s, found - %d, added - %d',
+        debug(
+          'syncMediaTracks - finished sync, took - %s, found - %d, processed - %d, added - %d',
+          DateTimeUtils.formatDuration(syncDuration),
           syncFilesFoundCount,
+          syncFilesProcessedCount,
           syncFilesAddedCount,
-          DateTimeUtils.formatDuration(syncDuration));
+        );
       } finally {
         finalize();
       }
@@ -332,6 +335,15 @@ class MediaLocalLibraryService implements IMediaLibraryService {
         file_size: file.stats?.size,
       },
       sync_timestamp: scanTimestamp,
+    });
+
+    // update stats
+    mediaLocalStore.dispatch({
+      type: MediaLocalStateActionType.IncrementDirectorySyncFilesAdded,
+      data: {
+        directory,
+        count: 1,
+      },
     });
 
     debug('addTracksFromFiles - added track %s from file %s', mediaTrack.id, file.path);

--- a/src/providers/media-local/media-local-library.service.ts
+++ b/src/providers/media-local/media-local-library.service.ts
@@ -14,11 +14,13 @@ import { IMediaLibraryService } from '../../interfaces';
 import { DateTimeUtils } from '../../utils';
 
 import {
+  I18nService,
   MediaAlbumService,
   MediaArtistService,
   MediaLibraryService,
   MediaProviderService,
   MediaTrackService,
+  NotificationService,
 } from '../../services';
 
 import { CryptoService } from '../../modules/crypto';
@@ -117,7 +119,18 @@ class MediaLocalLibraryService implements IMediaLibraryService {
           },
         });
 
-        debug('syncMediaTracks - finished sync, took - %s', DateTimeUtils.formatDuration(syncDuration));
+        // notification
+        const { syncFilesFoundCount, syncFilesAddedCount } = mediaLocalStore.getState();
+        if (syncFilesAddedCount > 0) {
+          NotificationService.showMessage(I18nService.getString('message_sync_finished', {
+            tracksAddedCount: syncFilesAddedCount,
+          }));
+        }
+
+        debug('syncMediaTracks - finished sync, took - %s, found - %d, added - %d',
+          syncFilesFoundCount,
+          syncFilesAddedCount,
+          DateTimeUtils.formatDuration(syncDuration));
       } finally {
         finalize();
       }

--- a/src/providers/media-local/media-local-library.service.ts
+++ b/src/providers/media-local/media-local-library.service.ts
@@ -195,12 +195,37 @@ class MediaLocalLibraryService implements IMediaLibraryService {
 
   private async addTrackFromFile(file: FSFile) {
     const mediaSyncTimestamp = Date.now();
+    // generate local id - we are using location of the file to uniquely identify the track
+    const mediaTrackId = MediaLocalLibraryService.getMediaId(file.path);
+
+    // // first check if we can simply mark it as seen; required both mtime and size for this to work
+    // if (isNumber(file.stats?.mtime) && isNumber(file.stats?.size)) {
+    //   const mediaTrack = await MediaTrackService.updateMediaTrack({
+    //     provider: MediaLocalConstants.Provider,
+    //     provider_id: mediaTrackId,
+    //     // @ts-ignore - can't get extra props to work with type checking
+    //     'extra.mtime': file.stats?.mtime,
+    //     'extra.size': file.stats?.size,
+    //   }, {
+    //     sync_timestamp: mediaSyncTimestamp,
+    //   });
+    //
+    //   if (mediaTrack) {
+    //     console.log('yolo', mediaTrack.extra);
+    //
+    //     // update media album
+    //
+    //     // update media artists
+    //
+    //     debug('addTracksFromDirectory - track at path %s already added %s, skipping...', file.path, mediaTrack.id);
+    //     return mediaTrack;
+    //   }
+    // }
+
     // read metadata
     const audioMetadata = await MediaLocalLibraryService.readAudioMetadataFromFile(file.path);
     // obtain cover image (important - there can be cases where audio has no cover image, handle accordingly)
     const audioCoverPicture = MediaLocalLibraryService.getAudioCoverPictureFromMetadata(audioMetadata);
-    // generate local id - we are using location of the file to uniquely identify the track
-    const mediaTrackId = MediaLocalLibraryService.getMediaId(file.path);
     // add media artist
     const mediaArtistDataList = await MediaLibraryService.checkAndInsertMediaArtists(audioMetadata.common.artists
       ? audioMetadata.common.artists.map(audioArtist => ({
@@ -246,6 +271,8 @@ class MediaLocalLibraryService implements IMediaLibraryService {
         location: {
           address: file.path,
         },
+        mtime: file.stats?.mtime,
+        size: file.stats?.size,
       },
       sync_timestamp: mediaSyncTimestamp,
     });

--- a/src/providers/media-local/media-local-playback.model.ts
+++ b/src/providers/media-local/media-local-playback.model.ts
@@ -1,4 +1,5 @@
 import { Howl } from 'howler';
+import { isEmpty } from 'lodash';
 
 import { IMediaPlayback, IMediaPlaybackOptions } from '../../interfaces';
 
@@ -14,9 +15,13 @@ export class MediaLocalPlayback implements IMediaPlayback {
   private mediaPlaybackEnded = false;
 
   constructor(mediaTrack: IMediaLocalTrack, mediaPlaybackOptions: IMediaPlaybackOptions) {
+    if (isEmpty(mediaTrack.extra.file_path)) {
+      throw new Error(`MediaLocalPlayback encountered error while loading track - ${mediaTrack.id} - Path must not be empty`);
+    }
+
     this.mediaTrack = mediaTrack;
     this.mediaPlaybackLocalAudio = new Howl({
-      src: mediaTrack.extra.location.address,
+      src: mediaTrack.extra.file_path,
       volume: MediaLocalPlayback.getVolumeForLocalAudioPlayer(mediaPlaybackOptions.mediaPlaybackVolume, mediaPlaybackOptions.mediaPlaybackMaxVolume),
       mute: mediaPlaybackOptions.mediaPlaybackVolumeMuted,
       // important - in order to support MediaSession, we need to used HTML5 audio

--- a/src/providers/media-local/media-local-settings.component.tsx
+++ b/src/providers/media-local/media-local-settings.component.tsx
@@ -93,7 +93,8 @@ export function MediaLocalSettingsComponent({ cx }: MediaLocalSettingsProps) {
     saving,
     syncing,
     syncDuration,
-    syncFileCount,
+    syncFilesFoundCount,
+    syncFilesAddedCount,
     syncDirectoryStats,
   } = state;
 
@@ -192,7 +193,11 @@ export function MediaLocalSettingsComponent({ cx }: MediaLocalSettingsProps) {
               <>
                 {I18nService.getString('tooltip_settings_sync_file_scanned')}
                 :&nbsp;
-                {syncFileCount}
+                {syncFilesFoundCount}
+                <br/>
+                {I18nService.getString('tooltip_settings_sync_file_added')}
+                :&nbsp;
+                {syncFilesAddedCount}
                 <br/>
                 {I18nService.getString('tooltip_settings_sync_time_taken')}
                 :&nbsp;

--- a/src/providers/media-local/media-local-settings.component.tsx
+++ b/src/providers/media-local/media-local-settings.component.tsx
@@ -191,7 +191,7 @@ export function MediaLocalSettingsComponent({ cx }: MediaLocalSettingsProps) {
             }}
             tooltip={(
               <>
-                {I18nService.getString('tooltip_settings_sync_file_scanned')}
+                {I18nService.getString('tooltip_settings_sync_file_found')}
                 :&nbsp;
                 {syncFilesFoundCount}
                 <br/>

--- a/src/providers/media-local/media-local-settings.component.tsx
+++ b/src/providers/media-local/media-local-settings.component.tsx
@@ -195,7 +195,7 @@ export function MediaLocalSettingsComponent({ cx }: MediaLocalSettingsProps) {
                 :&nbsp;
                 {syncFilesFoundCount}
                 <br/>
-                {I18nService.getString('tooltip_settings_sync_file_added')}
+                {I18nService.getString('tooltip_settings_sync_file_processed')}
                 :&nbsp;
                 {syncFilesProcessedCount}
                 <br/>

--- a/src/providers/media-local/media-local-settings.component.tsx
+++ b/src/providers/media-local/media-local-settings.component.tsx
@@ -43,7 +43,7 @@ function MediaDirectoryIcon(props: {
   } = props;
 
   const hasError = !isNil(stats.error);
-  const hasValidProgress = isNumber(stats.filesFound) && isNumber(stats.filesAdded);
+  const hasValidProgress = isNumber(stats.filesFound) && isNumber(stats.filesProcessed);
 
   if (hasError) {
     return (
@@ -62,7 +62,7 @@ function MediaDirectoryIcon(props: {
       );
     }
 
-    const progressPct = (stats.filesAdded! / stats.filesFound!) * 100;
+    const progressPct = (stats.filesProcessed! / stats.filesFound!) * 100;
 
     return (
       <LoaderCircleProgress
@@ -94,7 +94,7 @@ export function MediaLocalSettingsComponent({ cx }: MediaLocalSettingsProps) {
     syncing,
     syncDuration,
     syncFilesFoundCount,
-    syncFilesAddedCount,
+    syncFilesProcessedCount,
     syncDirectoryStats,
   } = state;
 
@@ -197,7 +197,7 @@ export function MediaLocalSettingsComponent({ cx }: MediaLocalSettingsProps) {
                 <br/>
                 {I18nService.getString('tooltip_settings_sync_file_added')}
                 :&nbsp;
-                {syncFilesAddedCount}
+                {syncFilesProcessedCount}
                 <br/>
                 {I18nService.getString('tooltip_settings_sync_time_taken')}
                 :&nbsp;

--- a/src/providers/media-local/media-local-settings.component.tsx
+++ b/src/providers/media-local/media-local-settings.component.tsx
@@ -35,9 +35,11 @@ function openDirectorySelectionDialog(): string | undefined {
 
 function MediaDirectoryIcon(props: {
   stats?: MediaSyncDirectoryStats;
+  syncing?: boolean;
 }) {
   const {
     stats = {},
+    syncing = false,
   } = props;
 
   const hasError = !isNil(stats.error);
@@ -53,17 +55,14 @@ function MediaDirectoryIcon(props: {
     );
   }
 
-  if (hasValidProgress) {
-    const progressPct = (stats.filesAdded! / stats.filesFound!) * 100;
-
-    if (progressPct === 100) {
+  if (syncing) {
+    if (!hasValidProgress) {
       return (
-        <Icon
-          name={Icons.Completed}
-          className={cl('settings-directory-icon-success')}
-        />
+        <LoaderCircle size={16}/>
       );
     }
+
+    const progressPct = (stats.filesAdded! / stats.filesFound!) * 100;
 
     return (
       <LoaderCircleProgress
@@ -74,7 +73,10 @@ function MediaDirectoryIcon(props: {
   }
 
   return (
-    <LoaderCircle size={16}/>
+    <Icon
+      name={Icons.Completed}
+      className={cl('settings-directory-icon-success')}
+    />
   );
 }
 
@@ -147,7 +149,7 @@ export function MediaLocalSettingsComponent({ cx }: MediaLocalSettingsProps) {
               return {
                 id: directory,
                 label: directory,
-                icon: (<MediaDirectoryIcon stats={dirStats}/>),
+                icon: (<MediaDirectoryIcon stats={dirStats} syncing={syncing}/>),
               };
             })}
             onRemove={(directory) => {

--- a/src/providers/media-local/media-local.interfaces.ts
+++ b/src/providers/media-local/media-local.interfaces.ts
@@ -10,6 +10,8 @@ export interface IMediaLocalTrack extends IMediaTrack {
   extra: {
     location: {
       address: string;
-    }
+    },
+    mtime?: number;
+    size?: number;
   }
 }

--- a/src/providers/media-local/media-local.interfaces.ts
+++ b/src/providers/media-local/media-local.interfaces.ts
@@ -8,10 +8,9 @@ export interface IMediaLocalSettings {
 
 export interface IMediaLocalTrack extends IMediaTrack {
   extra: {
-    location: {
-      address: string;
-    },
-    mtime?: number;
-    size?: number;
+    file_source: string;
+    file_path: string;
+    file_mtime?: number;
+    file_size?: number;
   }
 }

--- a/src/providers/media-local/media-local.store.ts
+++ b/src/providers/media-local/media-local.store.ts
@@ -151,6 +151,7 @@ function mediaLocalStateReducer(state: MediaLocalState = mediaLocalInitialState,
         syncDuration: 0,
         syncFilesFoundCount: 0,
         syncFilesProcessedCount: 0,
+        syncFilesAddedCount: 0,
         syncDirectoryStats: {},
       };
     }

--- a/src/providers/media-local/media-local.store.ts
+++ b/src/providers/media-local/media-local.store.ts
@@ -13,14 +13,14 @@ export enum MediaLocalStateActionType {
   StartSync = 'mediaLocalSettings/startSync',
   FinishSync = 'mediaLocalSettings/finishSync',
   IncrementDirectorySyncFilesFound = 'mediaLocalSettings/incrementDirectorySyncFilesFound',
-  IncrementDirectorySyncFilesAdded = 'mediaLocalSettings/incrementDirectorySyncFilesAdded',
+  IncrementDirectorySyncFilesProcessed = 'mediaLocalSettings/incrementDirectorySyncFilesProcessed',
   SetDirectorySyncError = 'mediaLocalSettings/setDirectorySyncError',
 }
 
 export type MediaSyncDirectoryStats = {
   error?: string,
   filesFound?: number,
-  filesAdded?: number,
+  filesProcessed?: number,
 };
 
 export type MediaLocalState = {
@@ -33,7 +33,7 @@ export type MediaLocalState = {
   syncing: boolean,
   syncDuration: number, // in ms
   syncFilesFoundCount: number,
-  syncFilesAddedCount: number,
+  syncFilesProcessedCount: number,
   syncDirectoryStats: Record<string, MediaSyncDirectoryStats>,
 };
 
@@ -55,7 +55,7 @@ const mediaLocalInitialState: MediaLocalState = {
   saved: false,
   syncing: false,
   syncDuration: 0,
-  syncFilesAddedCount: 0,
+  syncFilesProcessedCount: 0,
   syncFilesFoundCount: 0,
   syncDirectoryStats: {},
 };
@@ -146,7 +146,7 @@ function mediaLocalStateReducer(state: MediaLocalState = mediaLocalInitialState,
         syncing: true,
         syncDuration: 0,
         syncFilesFoundCount: 0,
-        syncFilesAddedCount: 0,
+        syncFilesProcessedCount: 0,
         syncDirectoryStats: {},
       };
     }
@@ -195,21 +195,21 @@ function mediaLocalStateReducer(state: MediaLocalState = mediaLocalInitialState,
         },
       };
     }
-    case MediaLocalStateActionType.IncrementDirectorySyncFilesAdded: {
+    case MediaLocalStateActionType.IncrementDirectorySyncFilesProcessed: {
       // data.directory - string
       // data.count - number
       const { directory, count } = action.data;
-      const dirCount = (state.syncDirectoryStats[directory]?.filesAdded || 0) + count;
-      const totalCount = state.syncFilesAddedCount + count;
+      const dirCount = (state.syncDirectoryStats[directory]?.filesProcessed || 0) + count;
+      const totalCount = state.syncFilesProcessedCount + count;
 
       return {
         ...state,
-        syncFilesAddedCount: totalCount,
+        syncFilesProcessedCount: totalCount,
         syncDirectoryStats: {
           ...state.syncDirectoryStats,
           [directory]: {
             ...(state.syncDirectoryStats[directory] || {}),
-            filesAdded: dirCount,
+            filesProcessed: dirCount,
           },
         },
       };

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -8,7 +8,7 @@ export type AppDetails = {
   logs_path: string;
 };
 
-export default class AppService {
+export class AppService {
   private static Details: AppDetails;
 
   static get details(): AppDetails {

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -2,30 +2,24 @@ import LocalizedStrings, { LocalizedStringsMethods } from 'react-localization';
 
 import { IPCRenderer, IPCCommChannel } from '../modules/ipc';
 
-class I18nService {
-  private readonly localeAssetPath = 'locales';
-  private readonly localeDefault = 'en';
-  private readonly localeStrings: LocalizedStringsMethods;
+export class I18nService {
+  private static readonly localeAssetPath = 'locales';
+  private static readonly localeDefault = 'en';
+  private static readonly localeStrings: LocalizedStringsMethods = new LocalizedStrings({
+    [this.localeDefault]: this.getLocaleFile(this.localeDefault),
+  });
 
-  constructor() {
-    const localeAssets: any = {};
-    localeAssets[this.localeDefault] = this.getLocaleFile(this.localeDefault);
-    this.localeStrings = new LocalizedStrings(localeAssets);
-  }
-
-  getString(key: string, values?: Record<string, string | number | JSX.Element>): string {
+  static getString(key: string, values?: Record<string, string | number | JSX.Element>): string {
     // values can be named object for string substitution
     // @see - https://www.npmjs.com/package/react-localization#api
     // @ts-ignore
     return this.localeStrings.formatString(this.localeStrings[key], values) as string;
   }
 
-  private getLocaleFile(locale: string): object {
+  private static getLocaleFile(locale: string): object {
     const localeRaw = IPCRenderer.sendSyncMessage(IPCCommChannel.FSReadAsset, [this.localeAssetPath, `${locale}.json`], {
       encoding: 'utf8',
     });
     return JSON.parse(localeRaw);
   }
 }
-
-export default new I18nService();

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,17 +1,23 @@
-import AppService from './app.service';
-import I18nService from './i18n.service';
-import MediaCollectionService from './media-collection.service';
-import MediaLibraryService from './media-library.service';
-import MediaLikedTrackService from './media-liked-track.service';
-import MediaPinnedItemService from './media-pinned-item.service';
 import MediaPlayerService from './media-player.service';
-import MediaPlaylistService from './media-playlist.service';
-import MediaProviderService from './media-provider.service';
-import NotificationService from './notification.service';
+
+import { I18nService } from './i18n.service';
+import { AppService } from './app.service';
+import { MediaAlbumService } from './media-album.service';
+import { MediaArtistService } from './media-artist.service';
+import { MediaCollectionService } from './media-collection.service';
+import { MediaLibraryService } from './media-library.service';
+import { MediaLikedTrackService } from './media-liked-track.service';
+import { MediaPinnedItemService } from './media-pinned-item.service';
+import { MediaPlaylistService } from './media-playlist.service';
+import { MediaProviderService } from './media-provider.service';
+import { MediaTrackService } from './media-track.service';
+import { NotificationService } from './notification.service';
 
 export {
   AppService,
   I18nService,
+  MediaAlbumService,
+  MediaArtistService,
   MediaCollectionService,
   MediaLibraryService,
   MediaLikedTrackService,
@@ -19,5 +25,6 @@ export {
   MediaPlayerService,
   MediaPlaylistService,
   MediaProviderService,
+  MediaTrackService,
   NotificationService,
 };

--- a/src/services/media-album.service.ts
+++ b/src/services/media-album.service.ts
@@ -1,0 +1,116 @@
+import _ from 'lodash';
+
+import { MediaAlbumDatastore } from '../datastores';
+import { MediaLibraryActions } from '../enums';
+import { IMediaAlbum, IMediaAlbumData } from '../interfaces';
+import { MediaUtils } from '../utils';
+import store from '../store';
+
+import { MediaArtistService } from './media-artist.service';
+
+export class MediaAlbumService {
+  static async searchAlbumsByName(query: string): Promise<IMediaAlbum[]> {
+    const albums = await MediaAlbumDatastore.findMediaAlbums({
+      album_name: {
+        $regex: new RegExp(query, 'i'),
+      },
+    });
+
+    return this.buildMediaAlbums(albums);
+  }
+
+  static async getMediaAlbum(albumId: string): Promise<IMediaAlbum | undefined> {
+    const albumData = await MediaAlbumDatastore.findMediaAlbumById(albumId);
+    return albumData ? this.buildMediaAlbum(albumData) : undefined;
+  }
+
+  static async getMediaAlbums(): Promise<IMediaAlbum[]> {
+    const mediaAlbumDataList = await MediaAlbumDatastore.findMediaAlbums();
+
+    const mediaAlbums = await Promise.all(mediaAlbumDataList.map(mediaAlbumData => this.buildMediaAlbum(mediaAlbumData)));
+    return MediaUtils.sortMediaAlbums(mediaAlbums);
+  }
+
+  static async getMediaArtistAlbums(mediaArtistId: string): Promise<IMediaAlbum[]> {
+    const mediaAlbumDataList = await MediaAlbumDatastore.findMediaAlbums({
+      album_artist_id: mediaArtistId,
+    });
+
+    const mediaAlbums = await Promise.all(mediaAlbumDataList.map(mediaAlbumData => this.buildMediaAlbum(mediaAlbumData)));
+    return MediaUtils.sortMediaAlbums(mediaAlbums);
+  }
+
+  static loadMediaAlbums(): void {
+    this
+      .getMediaAlbums()
+      .then((mediaAlbums) => {
+        store.dispatch({
+          type: MediaLibraryActions.SetAlbums,
+          data: {
+            mediaAlbums,
+          },
+        });
+      });
+  }
+
+  static loadMediaArtistAlbums(mediaArtistId: string): void {
+    this
+      .getMediaArtistAlbums(mediaArtistId)
+      .then(async (mediaArtistAlbums) => {
+        store.dispatch({
+          type: MediaLibraryActions.SetArtist,
+          data: {
+            mediaArtist: await MediaArtistService.getMediaArtist(mediaArtistId),
+            mediaArtistAlbums,
+          },
+        });
+      });
+  }
+
+  static unloadMediaAlbum(): void {
+    store.dispatch({
+      type: MediaLibraryActions.SetAlbum,
+      data: {
+        mediaAlbum: undefined,
+        mediaAlbumTracks: undefined,
+      },
+    });
+  }
+
+  static async buildMediaAlbum(mediaAlbum: string | IMediaAlbumData, loadMediaAlbum = false): Promise<IMediaAlbum> {
+    let mediaAlbumData;
+    if (typeof mediaAlbum === 'string') {
+      mediaAlbumData = await MediaAlbumDatastore.findMediaAlbumById(mediaAlbum);
+
+      if (!mediaAlbumData) {
+        throw new Error(`MediaLibraryService encountered error at buildMediaAlbum - Could not find album - ${mediaAlbum}`);
+      }
+    } else {
+      mediaAlbumData = mediaAlbum;
+    }
+
+    const mediaAlbumArtist = await MediaArtistService.getMediaArtist(mediaAlbumData.album_artist_id);
+    if (!mediaAlbumArtist) {
+      throw new Error(`Encountered error while build media album - ${mediaAlbumData.id} - Could not find artist with id - ${mediaAlbumData.album_artist_id}`);
+    }
+
+    const mediaAlbumBuilt = _.assign({}, mediaAlbumData, {
+      album_artist: mediaAlbumArtist,
+    });
+
+    if (loadMediaAlbum) {
+      store.dispatch({
+        type: MediaLibraryActions.AddAlbum,
+        data: {
+          mediaAlbum: mediaAlbumBuilt,
+        },
+      });
+    }
+
+    return mediaAlbumBuilt;
+  }
+
+  static async buildMediaAlbums(mediaAlbums: string[] | IMediaAlbumData[], loadMediaAlbums = false): Promise<IMediaAlbum[]> {
+    return Promise.all(mediaAlbums.map((mediaAlbum: any) => this.buildMediaAlbum(mediaAlbum, loadMediaAlbums)));
+  }
+}

--- a/src/services/media-album.service.ts
+++ b/src/services/media-album.service.ts
@@ -7,6 +7,7 @@ import { MediaUtils } from '../utils';
 import store from '../store';
 
 import { MediaArtistService } from './media-artist.service';
+import { DataStoreFilterData, DataStoreUpdateData } from '../modules/datastore';
 
 export class MediaAlbumService {
   static async searchAlbumsByName(query: string): Promise<IMediaAlbum[]> {
@@ -38,6 +39,15 @@ export class MediaAlbumService {
 
     const mediaAlbums = await Promise.all(mediaAlbumDataList.map(mediaAlbumData => this.buildMediaAlbum(mediaAlbumData)));
     return MediaUtils.sortMediaAlbums(mediaAlbums);
+  }
+
+  static async updateMediaAlbum(mediaAlbumFilterData: DataStoreFilterData<IMediaAlbumData>, mediaAlbumUpdateData: DataStoreUpdateData<IMediaAlbumData>): Promise<IMediaAlbum | undefined> {
+    const mediaAlbumData = await MediaAlbumDatastore.updateMediaAlbum(mediaAlbumFilterData, mediaAlbumUpdateData);
+    if (!mediaAlbumData) {
+      return undefined;
+    }
+
+    return this.buildMediaAlbum(mediaAlbumData, true);
   }
 
   static loadMediaAlbums(): void {

--- a/src/services/media-artist.service.ts
+++ b/src/services/media-artist.service.ts
@@ -2,6 +2,7 @@ import { MediaArtistDatastore } from '../datastores';
 import { MediaLibraryActions } from '../enums';
 import { IMediaArtist, IMediaArtistData } from '../interfaces';
 import { MediaUtils } from '../utils';
+import { DataStoreFilterData, DataStoreUpdateData } from '../modules/datastore';
 import store from '../store';
 
 export class MediaArtistService {
@@ -25,6 +26,11 @@ export class MediaArtistService {
 
     const mediaArtists = await Promise.all(mediaArtistDataList.map(mediaArtistData => this.buildMediaArtist(mediaArtistData)));
     return MediaUtils.sortMediaArtists(mediaArtists);
+  }
+
+  static async updateMediaArtists(mediaArtistFilterData: DataStoreFilterData<IMediaArtistData>, mediaArtistUpdateData: DataStoreUpdateData<IMediaArtistData>): Promise<IMediaArtist[] | undefined> {
+    const mediaAlbumDataList = await MediaArtistDatastore.updateArtists(mediaArtistFilterData, mediaArtistUpdateData);
+    return this.buildMediaArtists(mediaAlbumDataList, true);
   }
 
   static loadMediaArtists(): void {

--- a/src/services/media-artist.service.ts
+++ b/src/services/media-artist.service.ts
@@ -1,0 +1,81 @@
+import { MediaArtistDatastore } from '../datastores';
+import { MediaLibraryActions } from '../enums';
+import { IMediaArtist, IMediaArtistData } from '../interfaces';
+import { MediaUtils } from '../utils';
+import store from '../store';
+
+export class MediaArtistService {
+  static async searchArtistsByName(query: string): Promise<IMediaArtist[]> {
+    const artists = await MediaArtistDatastore.findMediaArtists({
+      artist_name: {
+        $regex: new RegExp(query, 'i'),
+      },
+    });
+
+    return this.buildMediaArtists(artists);
+  }
+
+  static async getMediaArtist(artistId: string): Promise<IMediaArtist | undefined> {
+    const artistData = await MediaArtistDatastore.findMediaArtistById(artistId);
+    return artistData ? this.buildMediaArtist(artistData) : undefined;
+  }
+
+  static async getMediaArtists(): Promise<IMediaArtist[]> {
+    const mediaArtistDataList = await MediaArtistDatastore.findMediaArtists();
+
+    const mediaArtists = await Promise.all(mediaArtistDataList.map(mediaArtistData => this.buildMediaArtist(mediaArtistData)));
+    return MediaUtils.sortMediaArtists(mediaArtists);
+  }
+
+  static loadMediaArtists(): void {
+    this
+      .getMediaArtists()
+      .then((mediaArtists) => {
+        store.dispatch({
+          type: MediaLibraryActions.SetArtists,
+          data: {
+            mediaArtists,
+          },
+        });
+      });
+  }
+
+  static unloadMediaArtist(): void {
+    store.dispatch({
+      type: MediaLibraryActions.SetArtist,
+      data: {
+        mediaArtist: undefined,
+        mediaArtistAlbums: undefined,
+      },
+    });
+  }
+
+  static async buildMediaArtist(mediaArtist: string | IMediaArtistData, loadMediaArtist = false): Promise<IMediaArtist> {
+    // info - no further processing required for MediaArtistData -> MediaArtist
+    let mediaArtistData;
+    if (typeof mediaArtist === 'string') {
+      mediaArtistData = await MediaArtistDatastore.findMediaArtistById(mediaArtist);
+
+      if (!mediaArtistData) {
+        throw new Error(`MediaLibraryService encountered error at buildMediaArtist - Could not find artist - ${mediaArtist}`);
+      }
+    } else {
+      mediaArtistData = mediaArtist;
+    }
+
+    if (loadMediaArtist) {
+      store.dispatch({
+        type: MediaLibraryActions.AddArtist,
+        data: {
+          mediaArtist: mediaArtistData,
+        },
+      });
+    }
+
+    return mediaArtistData;
+  }
+
+  static async buildMediaArtists(mediaArtists: string[] | IMediaArtistData[], loadMediaArtists = false): Promise<IMediaArtist[]> {
+    return Promise.all(mediaArtists.map((mediaArtist: any) => this.buildMediaArtist(mediaArtist, loadMediaArtists)));
+  }
+}

--- a/src/services/media-collection.service.ts
+++ b/src/services/media-collection.service.ts
@@ -11,28 +11,30 @@ import { Icons, Routes } from '../constants';
 import { MediaCollectionItemType } from '../enums';
 import { StringUtils } from '../utils';
 
-import MediaLibraryService from './media-library.service';
-import MediaLikedTrackService from './media-liked-track.service';
-import MediaPlaylistService from './media-playlist.service';
-import I18nService from './i18n.service';
+import { I18nService } from './i18n.service';
+import { MediaAlbumService } from './media-album.service';
+import { MediaArtistService } from './media-artist.service';
+import { MediaTrackService } from './media-track.service';
+import { MediaLikedTrackService } from './media-liked-track.service';
+import { MediaPlaylistService } from './media-playlist.service';
 
-class MediaCollectionService {
-  async searchCollection(query: string): Promise<IMediaCollectionSearchResults> {
+export class MediaCollectionService {
+  static async searchCollection(query: string): Promise<IMediaCollectionSearchResults> {
     return {
-      tracks: await MediaLibraryService.searchTracksByName(query),
-      albums: await MediaLibraryService.searchAlbumsByName(query),
-      artists: await MediaLibraryService.searchArtistsByName(query),
+      tracks: await MediaTrackService.searchTracksByName(query),
+      albums: await MediaAlbumService.searchAlbumsByName(query),
+      artists: await MediaArtistService.searchArtistsByName(query),
       playlists: await MediaPlaylistService.searchPlaylistsByName(query),
     };
   }
 
-  async getMediaCollectionTracks(mediaCollectionItem: IMediaCollectionItem): Promise<IMediaTrack[]> {
+  static async getMediaCollectionTracks(mediaCollectionItem: IMediaCollectionItem): Promise<IMediaTrack[]> {
     switch (mediaCollectionItem.type) {
       case MediaCollectionItemType.Album: {
-        return MediaLibraryService.getMediaAlbumTracks(mediaCollectionItem.id);
+        return MediaTrackService.getMediaAlbumTracks(mediaCollectionItem.id);
       }
       case MediaCollectionItemType.Artist: {
-        return MediaLibraryService.getMediaArtistTracks(mediaCollectionItem.id);
+        return MediaTrackService.getMediaArtistTracks(mediaCollectionItem.id);
       }
       case MediaCollectionItemType.Playlist: {
         return MediaPlaylistService.resolveMediaPlaylistTracks(mediaCollectionItem.id);
@@ -45,7 +47,7 @@ class MediaCollectionService {
     }
   }
 
-  getMediaItemFromAlbum(mediaAlbum: IMediaAlbum): IMediaCollectionItem {
+  static getMediaItemFromAlbum(mediaAlbum: IMediaAlbum): IMediaCollectionItem {
     return {
       id: mediaAlbum.id,
       type: MediaCollectionItemType.Album,
@@ -54,7 +56,7 @@ class MediaCollectionService {
     };
   }
 
-  getMediaItemFromArtist(mediaArtist: IMediaArtist): IMediaCollectionItem {
+  static getMediaItemFromArtist(mediaArtist: IMediaArtist): IMediaCollectionItem {
     return {
       id: mediaArtist.id,
       name: mediaArtist.artist_name,
@@ -63,7 +65,7 @@ class MediaCollectionService {
     };
   }
 
-  getMediaItemFromPlaylist(mediaPlaylist: IMediaPlaylist): IMediaCollectionItem {
+  static getMediaItemFromPlaylist(mediaPlaylist: IMediaPlaylist): IMediaCollectionItem {
     return {
       id: mediaPlaylist.id,
       name: mediaPlaylist.name,
@@ -72,7 +74,7 @@ class MediaCollectionService {
     };
   }
 
-  getMediaItemForLikedTracks() {
+  static getMediaItemForLikedTracks() {
     return {
       id: 'liked-tracks',
       name: I18nService.getString('label_liked_tracks_collection_name'),
@@ -81,7 +83,7 @@ class MediaCollectionService {
     };
   }
 
-  getItemCoverPlaceholderIcon(mediaCollectionItem: IMediaCollectionItem): string {
+  static getItemCoverPlaceholderIcon(mediaCollectionItem: IMediaCollectionItem): string {
     switch (mediaCollectionItem.type) {
       case MediaCollectionItemType.Artist:
         return Icons.ArtistPlaceholder;
@@ -96,7 +98,7 @@ class MediaCollectionService {
     }
   }
 
-  getItemRouterLink(mediaCollectionItem: IMediaCollectionItem): string {
+  static getItemRouterLink(mediaCollectionItem: IMediaCollectionItem): string {
     switch (mediaCollectionItem.type) {
       case MediaCollectionItemType.Album:
         return StringUtils.buildRoute(Routes.LibraryAlbum, {
@@ -117,7 +119,7 @@ class MediaCollectionService {
     }
   }
 
-  getItemSubtitle(mediaCollectionItem: IMediaCollectionItem): string {
+  static getItemSubtitle(mediaCollectionItem: IMediaCollectionItem): string {
     switch (mediaCollectionItem.type) {
       case MediaCollectionItemType.Artist:
         return I18nService.getString('label_artist_header');
@@ -131,14 +133,14 @@ class MediaCollectionService {
     }
   }
 
-  async getMediaItem(id: string, type: MediaCollectionItemType): Promise<IMediaCollectionItem | undefined> {
+  static async getMediaItem(id: string, type: MediaCollectionItemType): Promise<IMediaCollectionItem | undefined> {
     switch (type) {
       case MediaCollectionItemType.Album: {
-        const album = await MediaLibraryService.getMediaAlbum(id);
+        const album = await MediaAlbumService.getMediaAlbum(id);
         return album ? this.getMediaItemFromAlbum(album) : undefined;
       }
       case MediaCollectionItemType.Artist: {
-        const artist = await MediaLibraryService.getMediaArtist(id);
+        const artist = await MediaArtistService.getMediaArtist(id);
         return artist ? this.getMediaItemFromArtist(artist) : undefined;
       }
       case MediaCollectionItemType.Playlist: {
@@ -153,5 +155,3 @@ class MediaCollectionService {
     }
   }
 }
-
-export default new MediaCollectionService();

--- a/src/services/media-liked-track.service.ts
+++ b/src/services/media-liked-track.service.ts
@@ -7,14 +7,14 @@ import { MediaLibraryActions } from '../enums';
 import { EntityNotFoundError } from '../types';
 import { MediaUtils } from '../utils';
 
-import MediaLibraryService from './media-library.service';
-import NotificationService from './notification.service';
-import I18nService from './i18n.service';
+import { I18nService } from './i18n.service';
+import { MediaTrackService } from './media-track.service';
+import { NotificationService } from './notification.service';
 
-class MediaLikedTrackService {
-  readonly removeOnMissing = false;
+export class MediaLikedTrackService {
+  static readonly removeOnMissing = false;
 
-  loadLikedTracks() {
+  static loadLikedTracks() {
     this.resolveLikedTracks()
       .then((tracks: IMediaLikedTrack[]) => {
         store.dispatch({
@@ -29,7 +29,7 @@ class MediaLikedTrackService {
       });
   }
 
-  loadTrackLikedStatus(input: IMediaLikedTrackInputData) {
+  static loadTrackLikedStatus(input: IMediaLikedTrackInputData) {
     this.getLikedTrack(input)
       .then((mediaLikedTrack) => {
         if (mediaLikedTrack) {
@@ -53,7 +53,7 @@ class MediaLikedTrackService {
       });
   }
 
-  async getLikedTrack(input: IMediaLikedTrackInputData): Promise<IMediaLikedTrack | undefined> {
+  static async getLikedTrack(input: IMediaLikedTrackInputData): Promise<IMediaLikedTrack | undefined> {
     try {
       const likedTrackData = await MediaLikedTrackDatastore.findLikedTrack({
         provider: input.provider,
@@ -71,7 +71,7 @@ class MediaLikedTrackService {
     }
   }
 
-  async resolveLikedTracks(): Promise<IMediaLikedTrack[]> {
+  static async resolveLikedTracks(): Promise<IMediaLikedTrack[]> {
     // this function fetches liked tracks along with the linked media track
     // in case media track is not found, it removes the liked track entry (if enabled)
     const likedTrackDataList = await MediaLikedTrackDatastore.findLikedTracks();
@@ -102,7 +102,7 @@ class MediaLikedTrackService {
     return MediaUtils.sortMediaLikedTracks(likedTracks);
   }
 
-  async addTrackToLiked(input: IMediaLikedTrackInputData, options?: { skipUserNotification?: boolean }): Promise<IMediaLikedTrack> {
+  static async addTrackToLiked(input: IMediaLikedTrackInputData, options?: { skipUserNotification?: boolean }): Promise<IMediaLikedTrack> {
     // we will always remove existing entry before adding a new one
     await this.removeTrackFromLiked({
       provider: input.provider,
@@ -134,7 +134,7 @@ class MediaLikedTrackService {
     return likedTrack;
   }
 
-  async addTracksToLiked(inputList: IMediaLikedTrackInputData[], options?: { skipUserNotification?: boolean }): Promise<IMediaLikedTrack[]> {
+  static async addTracksToLiked(inputList: IMediaLikedTrackInputData[], options?: { skipUserNotification?: boolean }): Promise<IMediaLikedTrack[]> {
     const mediaLikedTracks = await Promise.map(inputList, input => this.addTrackToLiked({
       provider: input.provider,
       provider_id: input.provider_id,
@@ -149,7 +149,7 @@ class MediaLikedTrackService {
     return mediaLikedTracks;
   }
 
-  async removeTrackFromLiked(input: IMediaLikedTrackInputData, options?: { skipUserNotification?: boolean }): Promise<void> {
+  static async removeTrackFromLiked(input: IMediaLikedTrackInputData, options?: { skipUserNotification?: boolean }): Promise<void> {
     await MediaLikedTrackDatastore.deleteLikedTrack({
       provider: input.provider,
       provider_id: input.provider_id,
@@ -167,7 +167,7 @@ class MediaLikedTrackService {
     }
   }
 
-  async removeTracksFromLiked(inputList: IMediaLikedTrackInputData[], options?: { skipUserNotification?: boolean }): Promise<void> {
+  static async removeTracksFromLiked(inputList: IMediaLikedTrackInputData[], options?: { skipUserNotification?: boolean }): Promise<void> {
     await Promise.map(inputList, input => this.removeTrackFromLiked({
       provider: input.provider,
       provider_id: input.provider_id,
@@ -180,12 +180,12 @@ class MediaLikedTrackService {
     }
   }
 
-  async getLikedTracksCount(): Promise<number> {
+  static async getLikedTracksCount(): Promise<number> {
     return MediaLikedTrackDatastore.countLikedTracks();
   }
 
-  private async buildLikedTrack(likedTrackData: IMediaLikedTrackData): Promise<IMediaLikedTrack> {
-    const track = await MediaLibraryService.getMediaTrackForProvider(likedTrackData.provider, likedTrackData.provider_id);
+  private static async buildLikedTrack(likedTrackData: IMediaLikedTrackData): Promise<IMediaLikedTrack> {
+    const track = await MediaTrackService.getMediaTrackForProvider(likedTrackData.provider, likedTrackData.provider_id);
     if (!track) {
       throw new EntityNotFoundError(`${likedTrackData.provider}-${likedTrackData.provider_id}`, 'track');
     }
@@ -197,5 +197,3 @@ class MediaLikedTrackService {
     };
   }
 }
-
-export default new MediaLikedTrackService();

--- a/src/services/media-pinned-item.service.ts
+++ b/src/services/media-pinned-item.service.ts
@@ -6,12 +6,12 @@ import { IMediaPinnedItem, IMediaPinnedItemData, IMediaPinnedItemInputData } fro
 import { EntityNotFoundError } from '../types';
 import store from '../store';
 
-import MediaCollectionService from './media-collection.service';
+import { MediaCollectionService } from './media-collection.service';
 
-class MediaPinnedItemService {
-  readonly removeOnMissing = false;
+export class MediaPinnedItemService {
+  static readonly removeOnMissing = false;
 
-  loadPinnedItems() {
+  static loadPinnedItems() {
     this.resolvePinnedItems()
       .then((mediaPinnedItems) => {
         store.dispatch({
@@ -23,7 +23,7 @@ class MediaPinnedItemService {
       });
   }
 
-  loadPinnedItemStatus(input: IMediaPinnedItemInputData) {
+  static loadPinnedItemStatus(input: IMediaPinnedItemInputData) {
     this.getPinnedItem(input)
       .then((pinnedItem) => {
         if (pinnedItem) {
@@ -44,7 +44,7 @@ class MediaPinnedItemService {
       });
   }
 
-  async resolvePinnedItems(): Promise<IMediaPinnedItem[]> {
+  static async resolvePinnedItems(): Promise<IMediaPinnedItem[]> {
     // this function fetches pinned items along with their collection item
     // in case collection item entry is not found, it removes the pinned item (if enabled)
     const dataList = await MediaPinnedItemDatastore.find();
@@ -71,7 +71,7 @@ class MediaPinnedItemService {
     return items;
   }
 
-  async getPinnedItem(input: IMediaPinnedItemInputData): Promise<IMediaPinnedItem | undefined> {
+  static async getPinnedItem(input: IMediaPinnedItemInputData): Promise<IMediaPinnedItem | undefined> {
     try {
       const data = await MediaPinnedItemDatastore.findOne({
         collection_item_id: input.id,
@@ -89,7 +89,7 @@ class MediaPinnedItemService {
     }
   }
 
-  async pinCollectionItem(input: IMediaPinnedItemInputData): Promise<IMediaPinnedItem> {
+  static async pinCollectionItem(input: IMediaPinnedItemInputData): Promise<IMediaPinnedItem> {
     const newOrder = await this.getOrderForNewItem();
 
     const data = await MediaPinnedItemDatastore.insertOne({
@@ -111,7 +111,7 @@ class MediaPinnedItemService {
     return pinnedItem;
   }
 
-  async unpinCollectionItem(input: IMediaPinnedItemInputData): Promise<void> {
+  static async unpinCollectionItem(input: IMediaPinnedItemInputData): Promise<void> {
     await MediaPinnedItemDatastore.remove({
       collection_item_id: input.id,
       collection_item_type: input.type,
@@ -125,7 +125,7 @@ class MediaPinnedItemService {
     });
   }
 
-  async updatePinnedItemsOrder(itemIds: string[]): Promise<void> {
+  static async updatePinnedItemsOrder(itemIds: string[]): Promise<void> {
     // update order - itemIds need to be in the required order
     await Promise.map(itemIds, async (itemId, index) => MediaPinnedItemDatastore.updateOne(itemId, {
       order: index,
@@ -134,7 +134,7 @@ class MediaPinnedItemService {
     this.loadPinnedItems();
   }
 
-  private async getOrderForNewItem(): Promise<number> {
+  private static async getOrderForNewItem(): Promise<number> {
     // get the last pinned item for obtaining order
     // we start with 0 if not found (index based)
     const data = await MediaPinnedItemDatastore.find({}, {
@@ -149,7 +149,7 @@ class MediaPinnedItemService {
     return itemData.order + 1;
   }
 
-  private async buildPinnedItem(pinnedItemData: IMediaPinnedItemData): Promise<IMediaPinnedItem> {
+  private static async buildPinnedItem(pinnedItemData: IMediaPinnedItemData): Promise<IMediaPinnedItem> {
     const collectionItem = await MediaCollectionService.getMediaItem(
       pinnedItemData.collection_item_id,
       pinnedItemData.collection_item_type,
@@ -165,5 +165,3 @@ class MediaPinnedItemService {
     };
   }
 }
-
-export default new MediaPinnedItemService();

--- a/src/services/media-player.service.ts
+++ b/src/services/media-player.service.ts
@@ -13,9 +13,9 @@ import {
   IMediaTrackList,
 } from '../interfaces';
 
-import MediaProviderService from './media-provider.service';
-import NotificationService from './notification.service';
-import I18nService from './i18n.service';
+import { I18nService } from './i18n.service';
+import { MediaProviderService } from './media-provider.service';
+import { NotificationService } from './notification.service';
 
 const debug = require('debug')('aurora:service:media_player');
 

--- a/src/services/media-provider.service.ts
+++ b/src/services/media-provider.service.ts
@@ -1,12 +1,12 @@
-import { MediaEnums } from '../enums';
 import { MediaProviderDatastore } from '../datastores';
+import { MediaEnums } from '../enums';
 import { IMediaProvider } from '../interfaces';
 import store from '../store';
 
 const debug = require('debug')('aurora:service:media_provider');
 
-class MediaProviderService {
-  registerMediaProvider(mediaProvider: IMediaProvider) {
+export class MediaProviderService {
+  static registerMediaProvider(mediaProvider: IMediaProvider) {
     debug('registerMediaProvider - registering media provider - %s', mediaProvider.mediaProviderIdentifier);
 
     this.addProviderToDatastore(mediaProvider)
@@ -23,7 +23,7 @@ class MediaProviderService {
       });
   }
 
-  getMediaProvider(mediaProviderIdentifier: string): IMediaProvider {
+  static getMediaProvider(mediaProviderIdentifier: string): IMediaProvider {
     const { mediaProviderRegistry } = store.getState();
 
     const mediaProviderRequested = mediaProviderRegistry.mediaProviders.find(mediaProvider => mediaProvider.mediaProviderIdentifier === mediaProviderIdentifier);
@@ -34,7 +34,7 @@ class MediaProviderService {
     return mediaProviderRequested;
   }
 
-  async getMediaProviderSettings(mediaProviderIdentifier: string): Promise<any> {
+  static async getMediaProviderSettings(mediaProviderIdentifier: string): Promise<any> {
     debug('getMediaProviderSettings - fetching settings for - %s', mediaProviderIdentifier);
     const mediaProviderData = await MediaProviderDatastore.findMediaProviderByIdentifier(mediaProviderIdentifier);
     if (!mediaProviderData) {
@@ -45,7 +45,7 @@ class MediaProviderService {
     return mediaProviderData.settings;
   }
 
-  async updateMediaProviderSettings(mediaProviderIdentifier: string, mediaProviderSettings: object): Promise<void> {
+  static async updateMediaProviderSettings(mediaProviderIdentifier: string, mediaProviderSettings: object): Promise<void> {
     debug('updateMediaProviderSettings - getting existing settings for - %s', mediaProviderIdentifier);
     const mediaProvider = this.getMediaProvider(mediaProviderIdentifier);
     const mediaProviderExistingSettings = await this.getMediaProviderSettings(mediaProviderIdentifier);
@@ -63,7 +63,7 @@ class MediaProviderService {
     debug('updateMediaProviderSettings - updated settings - %s', mediaProviderIdentifier);
   }
 
-  private async addProviderToDatastore(mediaProvider: IMediaProvider): Promise<void> {
+  private static async addProviderToDatastore(mediaProvider: IMediaProvider): Promise<void> {
     // check if we already have an existing entry for the provider in the datastore, do nothing if entry already exists
     if (await MediaProviderDatastore.findMediaProviderByIdentifier(mediaProvider.mediaProviderIdentifier)) {
       return;
@@ -83,7 +83,7 @@ class MediaProviderService {
     });
   }
 
-  private addProviderToLocalStore(mediaProvider: IMediaProvider): void {
+  private static addProviderToLocalStore(mediaProvider: IMediaProvider): void {
     store.dispatch({
       type: MediaEnums.MediaProviderRegistryActions.AddProviderSafe,
       data: {
@@ -92,7 +92,7 @@ class MediaProviderService {
     });
   }
 
-  private initializeLibraryInLocalStore(mediaProvider: IMediaProvider): void {
+  private static initializeLibraryInLocalStore(mediaProvider: IMediaProvider): void {
     store.dispatch({
       type: MediaEnums.MediaLibraryActions.Initialize,
       data: {
@@ -101,5 +101,3 @@ class MediaProviderService {
     });
   }
 }
-
-export default new MediaProviderService();

--- a/src/services/media-track.service.ts
+++ b/src/services/media-track.service.ts
@@ -1,0 +1,103 @@
+import _ from 'lodash';
+
+import { MediaTrackDatastore } from '../datastores';
+import { IMediaTrack, IMediaTrackData } from '../interfaces';
+import { MediaLibraryActions } from '../enums';
+import { MediaUtils } from '../utils';
+import { DataStoreFilterData, DataStoreUpdateData } from '../modules/datastore';
+import store from '../store';
+
+import { MediaArtistService } from './media-artist.service';
+import { MediaAlbumService } from './media-album.service';
+
+export class MediaTrackService {
+  static async searchTracksByName(query: string): Promise<IMediaTrack[]> {
+    const tracks = await MediaTrackDatastore.findMediaTracks({
+      track_name: {
+        $regex: new RegExp(query, 'i'),
+      },
+    });
+
+    return this.buildMediaTracks(tracks);
+  }
+
+  static async getMediaTrack(mediaTrackId: string): Promise<IMediaTrack | undefined> {
+    const mediaTrackData = await MediaTrackDatastore.findMediaTrack({
+      id: mediaTrackId,
+    });
+
+    return mediaTrackData ? this.buildMediaTrack(mediaTrackData) : undefined;
+  }
+
+  static async getMediaTrackForProvider(provider: string, provider_id: string): Promise<IMediaTrack | undefined> {
+    const mediaTrackData = await MediaTrackDatastore.findMediaTrack({
+      provider,
+      provider_id,
+    });
+
+    return mediaTrackData ? this.buildMediaTrack(mediaTrackData) : undefined;
+  }
+
+  static async getMediaAlbumTracks(mediaAlbumId: string): Promise<IMediaTrack[]> {
+    const mediaAlbumTrackDataList = await MediaTrackDatastore.findMediaTracks({
+      track_album_id: mediaAlbumId,
+    });
+
+    const mediaAlbumTracks = await this.buildMediaTracks(mediaAlbumTrackDataList);
+    return MediaUtils.sortMediaAlbumTracks(mediaAlbumTracks);
+  }
+
+  static async getMediaArtistTracks(mediaArtistId: string): Promise<IMediaTrack[]> {
+    const mediaTrackDataList = await MediaTrackDatastore.findMediaTracks({
+      track_artist_ids: [mediaArtistId],
+    });
+
+    const mediaTracks = await this.buildMediaTracks(mediaTrackDataList);
+    return MediaUtils.sortMediaArtistTracks(mediaTracks);
+  }
+
+  static async updateMediaTrack(mediaTrackFilterData: DataStoreFilterData<IMediaTrackData>, mediaTrackUpdateData: DataStoreUpdateData<IMediaTrackData>): Promise<IMediaTrack | undefined> {
+    const mediaTrackData = await MediaTrackDatastore.updateMediaTrack(mediaTrackFilterData, mediaTrackUpdateData);
+    if (!mediaTrackData) {
+      return undefined;
+    }
+
+    return this.buildMediaTrack(mediaTrackData, true);
+  }
+
+  static loadMediaAlbumTracks(mediaAlbumId: string): void {
+    this
+      .getMediaAlbumTracks(mediaAlbumId)
+      .then(async (mediaAlbumTracks) => {
+        store.dispatch({
+          type: MediaLibraryActions.SetAlbum,
+          data: {
+            mediaAlbum: await MediaAlbumService.getMediaAlbum(mediaAlbumId),
+            mediaAlbumTracks,
+          },
+        });
+      });
+  }
+
+  static async buildMediaTrack(mediaTrackData: IMediaTrackData, loadMediaTrack = false): Promise<IMediaTrack> {
+    const mediaTrack = _.assign({}, mediaTrackData, {
+      track_artists: await MediaArtistService.buildMediaArtists(mediaTrackData.track_artist_ids, loadMediaTrack),
+      track_album: await MediaAlbumService.buildMediaAlbum(mediaTrackData.track_album_id, loadMediaTrack),
+    });
+
+    if (loadMediaTrack) {
+      store.dispatch({
+        type: MediaLibraryActions.AddTrack,
+        data: {
+          mediaTrack,
+        },
+      });
+    }
+
+    return mediaTrack;
+  }
+
+  static async buildMediaTracks(mediaTrackDataList: IMediaTrackData[], loadMediaTracks = false): Promise<IMediaTrack[]> {
+    return Promise.all(mediaTrackDataList.map(mediaTrackData => this.buildMediaTrack(mediaTrackData, loadMediaTracks)));
+  }
+}

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,9 +1,9 @@
 type NotificationListener = (message: string) => void;
 
-class NotificationService {
-  private listeners: NotificationListener[] = [];
+export class NotificationService {
+  private static listeners: NotificationListener[] = [];
 
-  subscribe(listener: NotificationListener) {
+  static subscribe(listener: NotificationListener) {
     this.listeners.push(listener);
 
     return () => {
@@ -11,9 +11,7 @@ class NotificationService {
     };
   }
 
-  showMessage(message: string) {
+  static showMessage(message: string) {
     this.listeners.forEach(listener => listener(message));
   }
 }
-
-export default new NotificationService();


### PR DESCRIPTION
## Description
- feat: Added support for mtime based syncing - If mtime (modified time) is not yet synced in filesystem - file is inserted/updated. If it is - file is skipped (uses `mediaTrack.extra.file_mtime`, `mediaTrack.extra.file_size`)
- feat: Added notification for new added tracks on sync finish
- fix: Album key is now decided by albumArtistName and albumName. We can now have same album name but for different artists.
- fix: This now correctly handles album artist based common metadata (common.albumartist) (#148).
- chore: Restructured service
- chore: `mediaTrack.extra.file_source` was added - selected directory from which track was sourced
- (**breaking**) chore: `mediaTrack.extra.location.address` was changed to `mediaTrack.extra.file_file_path`

## Tests

### Manual test cases run
- NA
